### PR TITLE
feat: gas budget tracker with configurable hour/day limits (closes #5)

### DIFF
--- a/switchboard/gas_budget.py
+++ b/switchboard/gas_budget.py
@@ -1,0 +1,233 @@
+"""
+Gas budget tracker for agent wallets.
+
+Tracks cumulative gas spent per wallet over rolling hour and day windows,
+enforces configurable limits, and pauses execution when a budget is exhausted.
+
+Implements issue #5:
+    https://github.com/kcolbchain/switchboard/issues/5
+
+Design goals
+------------
+- Monotonic, thread-safe accounting — safe from multiple agent worker threads.
+- Rolling-window enforcement (not calendar buckets), so a burst at 23:59 does
+  not reset to zero one minute later.
+- Pluggable clock for deterministic tests.
+- Pure Python, zero new runtime deps.
+
+Typical usage::
+
+    tracker = GasBudgetTracker(
+        default_limits=GasLimits(per_hour=2_000_000, per_day=20_000_000),
+    )
+
+    if not tracker.can_spend(wallet, estimated_gas):
+        raise BudgetExhausted(tracker.status(wallet))
+
+    # ... send tx ...
+    tracker.record(wallet, gas_used=receipt.gasUsed)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, Dict, Optional
+
+
+SECONDS_PER_HOUR = 3_600
+SECONDS_PER_DAY = 86_400
+
+
+class BudgetExhausted(RuntimeError):
+    """Raised when a wallet would exceed its configured gas budget."""
+
+
+@dataclass(frozen=True)
+class GasLimits:
+    """Per-wallet gas ceilings. ``None`` disables the corresponding window."""
+
+    per_hour: Optional[int] = None
+    per_day: Optional[int] = None
+
+
+@dataclass
+class BudgetStatus:
+    """Snapshot of a wallet's current spend vs. its limits."""
+
+    wallet: str
+    limits: GasLimits
+    spent_last_hour: int
+    spent_last_day: int
+    paused: bool
+
+    @property
+    def remaining_hour(self) -> Optional[int]:
+        if self.limits.per_hour is None:
+            return None
+        return max(0, self.limits.per_hour - self.spent_last_hour)
+
+    @property
+    def remaining_day(self) -> Optional[int]:
+        if self.limits.per_day is None:
+            return None
+        return max(0, self.limits.per_day - self.spent_last_day)
+
+
+@dataclass
+class _WalletLedger:
+    """Internal per-wallet state. Protected by the tracker lock."""
+
+    # (timestamp_seconds, gas_used) entries, oldest first.
+    events: Deque = field(default_factory=deque)
+    sum_hour: int = 0
+    sum_day: int = 0
+    paused: bool = False
+
+
+class GasBudgetTracker:
+    """Tracks cumulative gas per wallet and enforces rolling-window limits.
+
+    Parameters
+    ----------
+    default_limits:
+        Applied to any wallet that does not have explicit limits set via
+        :meth:`set_limits`.
+    clock:
+        Injectable seconds-resolution clock. Defaults to :func:`time.time`.
+        Tests should pass a controllable clock to avoid real sleeps.
+    """
+
+    def __init__(
+        self,
+        default_limits: GasLimits = GasLimits(),
+        clock: Callable[[], float] = time.time,
+    ):
+        self._default_limits = default_limits
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._ledgers: Dict[str, _WalletLedger] = defaultdict(_WalletLedger)
+        self._limits: Dict[str, GasLimits] = {}
+
+    # ---- configuration -------------------------------------------------
+
+    def set_limits(self, wallet: str, limits: GasLimits) -> None:
+        """Override the default limits for ``wallet``."""
+        with self._lock:
+            self._limits[wallet] = limits
+
+    def limits_for(self, wallet: str) -> GasLimits:
+        return self._limits.get(wallet, self._default_limits)
+
+    # ---- enforcement ---------------------------------------------------
+
+    def can_spend(self, wallet: str, estimated_gas: int) -> bool:
+        """Return ``True`` if ``estimated_gas`` fits within every active window."""
+        if estimated_gas < 0:
+            raise ValueError("estimated_gas must be non-negative")
+
+        with self._lock:
+            ledger = self._ledgers[wallet]
+            self._evict_locked(ledger)
+            limits = self.limits_for(wallet)
+
+            if ledger.paused:
+                return False
+            if limits.per_hour is not None and ledger.sum_hour + estimated_gas > limits.per_hour:
+                return False
+            if limits.per_day is not None and ledger.sum_day + estimated_gas > limits.per_day:
+                return False
+            return True
+
+    def check(self, wallet: str, estimated_gas: int) -> None:
+        """Raise :class:`BudgetExhausted` if ``estimated_gas`` cannot be spent."""
+        if not self.can_spend(wallet, estimated_gas):
+            raise BudgetExhausted(self.status(wallet))
+
+    def record(self, wallet: str, gas_used: int) -> BudgetStatus:
+        """Record a post-confirmation gas spend and return the new status.
+
+        Auto-pauses the wallet if a limit is crossed after this record.
+        """
+        if gas_used < 0:
+            raise ValueError("gas_used must be non-negative")
+
+        with self._lock:
+            ledger = self._ledgers[wallet]
+            self._evict_locked(ledger)
+
+            now = self._clock()
+            ledger.events.append((now, gas_used))
+            ledger.sum_hour += gas_used
+            ledger.sum_day += gas_used
+
+            limits = self.limits_for(wallet)
+            if (
+                limits.per_hour is not None and ledger.sum_hour >= limits.per_hour
+            ) or (
+                limits.per_day is not None and ledger.sum_day >= limits.per_day
+            ):
+                ledger.paused = True
+
+            return self._status_locked(wallet, ledger, limits)
+
+    # ---- introspection -------------------------------------------------
+
+    def status(self, wallet: str) -> BudgetStatus:
+        with self._lock:
+            ledger = self._ledgers[wallet]
+            self._evict_locked(ledger)
+            return self._status_locked(wallet, ledger, self.limits_for(wallet))
+
+    def resume(self, wallet: str) -> None:
+        """Manually unpause a wallet. The operator is responsible for ensuring
+        the underlying budget has freed up — this does not reset counters."""
+        with self._lock:
+            self._ledgers[wallet].paused = False
+
+    def reset(self, wallet: str) -> None:
+        """Clear all recorded spend for ``wallet`` (e.g. after a new funding round)."""
+        with self._lock:
+            self._ledgers[wallet] = _WalletLedger()
+
+    # ---- internals -----------------------------------------------------
+
+    def _evict_locked(self, ledger: _WalletLedger) -> None:
+        """Drop events that have aged out of both windows and refresh sums."""
+        now = self._clock()
+        day_cutoff = now - SECONDS_PER_DAY
+        hour_cutoff = now - SECONDS_PER_HOUR
+
+        # Evict from the daily window (which also removes from hourly).
+        while ledger.events and ledger.events[0][0] <= day_cutoff:
+            ts, gas = ledger.events.popleft()
+            ledger.sum_day -= gas
+            if ts > hour_cutoff:
+                # Shouldn't happen — hour window is a subset of day — but keep
+                # sums consistent defensively.
+                ledger.sum_hour -= gas
+
+        # Rebuild sum_hour from events (cheap: bounded by day window size).
+        ledger.sum_hour = sum(gas for ts, gas in ledger.events if ts > hour_cutoff)
+
+        # Auto-unpause if limits have freed up again.
+        if ledger.paused:
+            limits_ok_hour = True
+            limits_ok_day = True
+            # We don't know wallet limits here; caller re-checks before spending.
+            # We keep paused sticky until explicit resume() or a fresh record()
+            # re-evaluates. See docstring on resume().
+            del limits_ok_hour, limits_ok_day
+
+    def _status_locked(
+        self, wallet: str, ledger: _WalletLedger, limits: GasLimits
+    ) -> BudgetStatus:
+        return BudgetStatus(
+            wallet=wallet,
+            limits=limits,
+            spent_last_hour=ledger.sum_hour,
+            spent_last_day=ledger.sum_day,
+            paused=ledger.paused,
+        )

--- a/tests/test_gas_budget.py
+++ b/tests/test_gas_budget.py
@@ -1,0 +1,224 @@
+"""Tests for switchboard.gas_budget — see issue #5."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from switchboard.gas_budget import (
+    BudgetExhausted,
+    GasBudgetTracker,
+    GasLimits,
+    SECONDS_PER_DAY,
+    SECONDS_PER_HOUR,
+)
+
+
+class FakeClock:
+    """Deterministic monotonically-controllable clock."""
+
+    def __init__(self, start: float = 1_700_000_000.0):
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+WALLET = "0xAgent"
+
+
+# ---------------------------------------------------------------- basics
+
+
+def test_default_limits_allow_everything():
+    t = GasBudgetTracker()
+    assert t.can_spend(WALLET, 10**12) is True
+    t.record(WALLET, 10**12)
+    status = t.status(WALLET)
+    assert status.paused is False
+    assert status.remaining_hour is None
+    assert status.remaining_day is None
+
+
+def test_record_rejects_negative():
+    t = GasBudgetTracker()
+    with pytest.raises(ValueError):
+        t.record(WALLET, -1)
+    with pytest.raises(ValueError):
+        t.can_spend(WALLET, -1)
+
+
+# ---------------------------------------------------------------- hour
+
+
+def test_hourly_limit_blocks_overspend():
+    clock = FakeClock()
+    t = GasBudgetTracker(
+        default_limits=GasLimits(per_hour=100_000),
+        clock=clock,
+    )
+
+    assert t.can_spend(WALLET, 60_000)
+    t.record(WALLET, 60_000)
+
+    # 60k of 100k used — 50k more would exceed.
+    assert t.can_spend(WALLET, 30_000) is True
+    assert t.can_spend(WALLET, 50_000) is False
+
+
+def test_hourly_window_rolls_forward():
+    clock = FakeClock()
+    t = GasBudgetTracker(
+        default_limits=GasLimits(per_hour=100_000),
+        clock=clock,
+    )
+
+    t.record(WALLET, 90_000)
+    assert t.can_spend(WALLET, 20_000) is False
+
+    # Slide past the hour boundary.
+    clock.advance(SECONDS_PER_HOUR + 1)
+
+    # Spend should now fit — but wallet remains paused until operator resumes
+    # (prior spend exhausted the limit, pausing it). Resume and retry.
+    t.resume(WALLET)
+    assert t.can_spend(WALLET, 90_000) is True
+
+
+# ---------------------------------------------------------------- day
+
+
+def test_daily_limit_independent_of_hourly():
+    clock = FakeClock()
+    t = GasBudgetTracker(
+        default_limits=GasLimits(per_hour=50_000, per_day=120_000),
+        clock=clock,
+    )
+
+    for _ in range(3):
+        assert t.can_spend(WALLET, 40_000)
+        t.record(WALLET, 40_000)
+        clock.advance(SECONDS_PER_HOUR + 1)
+        t.resume(WALLET)  # re-enable after each hourly pause
+
+    # Day total now 120k == limit exactly; anything more should fail.
+    assert t.can_spend(WALLET, 1) is False
+
+
+def test_daily_window_rolls_forward():
+    clock = FakeClock()
+    t = GasBudgetTracker(
+        default_limits=GasLimits(per_day=100_000),
+        clock=clock,
+    )
+
+    t.record(WALLET, 100_000)
+    assert t.status(WALLET).paused is True
+
+    clock.advance(SECONDS_PER_DAY + 1)
+    t.resume(WALLET)
+    assert t.can_spend(WALLET, 100_000) is True
+    assert t.status(WALLET).spent_last_day == 0
+
+
+# ---------------------------------------------------------------- pause
+
+
+def test_pause_on_exhaustion_blocks_further_spending():
+    t = GasBudgetTracker(default_limits=GasLimits(per_hour=1_000))
+    t.record(WALLET, 1_000)
+    status = t.status(WALLET)
+    assert status.paused is True
+    assert t.can_spend(WALLET, 1) is False
+
+
+def test_check_raises_when_exhausted():
+    t = GasBudgetTracker(default_limits=GasLimits(per_hour=500))
+    t.record(WALLET, 500)
+    with pytest.raises(BudgetExhausted) as exc:
+        t.check(WALLET, 1)
+    assert exc.value.args[0].wallet == WALLET
+
+
+def test_resume_clears_pause_without_resetting_counters():
+    clock = FakeClock()
+    t = GasBudgetTracker(default_limits=GasLimits(per_hour=1_000), clock=clock)
+    t.record(WALLET, 1_000)
+    assert t.status(WALLET).paused is True
+
+    t.resume(WALLET)
+    status = t.status(WALLET)
+    assert status.paused is False
+    assert status.spent_last_hour == 1_000  # counters intact
+
+
+# ---------------------------------------------------------------- per-wallet
+
+
+def test_per_wallet_limits_override_default():
+    t = GasBudgetTracker(default_limits=GasLimits(per_hour=1_000))
+    t.set_limits("0xVIP", GasLimits(per_hour=10_000))
+
+    t.record("0xVIP", 5_000)
+    t.record(WALLET, 900)
+    assert t.status("0xVIP").paused is False
+    assert t.can_spend(WALLET, 500) is False  # default limit binds
+
+
+def test_wallets_are_isolated():
+    t = GasBudgetTracker(default_limits=GasLimits(per_hour=1_000))
+    t.record("a", 1_000)
+    assert t.status("a").paused is True
+    assert t.status("b").paused is False
+    assert t.can_spend("b", 999) is True
+
+
+# ---------------------------------------------------------------- reset
+
+
+def test_reset_clears_history():
+    t = GasBudgetTracker(default_limits=GasLimits(per_hour=100))
+    t.record(WALLET, 100)
+    t.reset(WALLET)
+    s = t.status(WALLET)
+    assert s.spent_last_hour == 0
+    assert s.paused is False
+    assert t.can_spend(WALLET, 100) is True
+
+
+# ---------------------------------------------------------------- threads
+
+
+def test_thread_safety_sum_is_exact():
+    t = GasBudgetTracker()  # no limits; just exercise locking
+    N = 500
+    workers = 8
+
+    def run():
+        for _ in range(N):
+            t.record(WALLET, 1)
+
+    threads = [threading.Thread(target=run) for _ in range(workers)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    assert t.status(WALLET).spent_last_hour == N * workers
+
+
+# ---------------------------------------------------------------- status
+
+
+def test_status_reports_remaining():
+    t = GasBudgetTracker(
+        default_limits=GasLimits(per_hour=10_000, per_day=100_000),
+    )
+    t.record(WALLET, 3_000)
+    s = t.status(WALLET)
+    assert s.remaining_hour == 7_000
+    assert s.remaining_day == 97_000


### PR DESCRIPTION
Closes #5. Adds per-wallet gas budget accounting.

- `switchboard/gas_budget.py` — `GasBudgetTracker`, `GasLimits`, `BudgetStatus`, `BudgetExhausted`.
- Rolling windows (not calendar buckets) — a burst at 23:59 cannot reset one minute later.
- Thread-safe; pluggable clock for deterministic tests.
- Pauses the wallet when a limit is crossed; operator calls `resume()` once the window clears.
- Zero new runtime deps.

## Test plan
- [x] 14 pytest cases in `tests/test_gas_budget.py`.
- [x] `PYTHONPATH=. pytest tests/test_gas_budget.py -q` → 14 passed.

Pre-existing failures in `tests/test_nonce_manager.py` are unrelated.