### PR TITLE
docs(readme): use research@kcolbchain.com (services@ not a live alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,6 @@ tests/test_zap_transport.py          ✅ 11 passed   (with luxfi-zap installed)
 
 MIT. Built by [kcolbchain](https://kcolbchain.com) — [@abhicris](https://github.com/abhicris).
 
-If you're building agent-payment infrastructure and want to compare notes — open an issue, or [services@kcolbchain.com](mailto:services@kcolbchain.com).
+If you're building agent-payment infrastructure and want to compare notes — open an issue, or [research@kcolbchain.com](mailto:research@kcolbchain.com).
 
 > **kcolb** = "block" reversed. We've been at this since 2015. The agent-payment rails are the part of crypto that finally has a real customer: AI.


### PR DESCRIPTION
The README contact footer pointed at `services@kcolbchain.com`, which is not a configured alias on our Gmail SMTP/IMAP. `research@kcolbchain.com` is the correct address (alongside `projects@`, `finance@`).

One-line README change. No code, no behavior.