### PR TITLE
feat(a2a): formalize agent-to-agent payment protocol spec + fix tests

### DIFF
--- a/docs/agent-payment-protocol.md
+++ b/docs/agent-payment-protocol.md
@@ -1,0 +1,175 @@
+# Agent-to-Agent Payment Protocol — switchboard
+
+**Status:** Draft v1.0
+**Reference impl:** [`src/payment_protocol.py`](../src/payment_protocol.py)
+**On-chain side:** [`contracts/AgentEscrow.sol`](../contracts/AgentEscrow.sol)
+**Tracks issue:** [#2 — Add agent-to-agent payment protocol](https://github.com/kcolbchain/switchboard/issues/2)
+
+---
+
+## 1. Goal
+
+Let two autonomous agents settle a payment for work without a human in the loop, with three properties:
+
+1. **Payee gets paid only if the work is accepted** (or after a timeout the payer can't grief past).
+2. **Payer can recover funds** if the payee disappears or fails to deliver.
+3. **The protocol is portable** across EVM-compatible chains.
+
+The wire format is JSON; the settlement is an on-chain escrow.
+
+## 2. Message format — `PaymentRequest`
+
+Canonical structure (all fields lowercase snake_case):
+
+| field                       | type    | required | notes                                                      |
+| --------------------------- | ------- | -------- | ---------------------------------------------------------- |
+| `version`                   | string  | yes      | Protocol version. Current = `"1.0"`.                       |
+| `request_id`                | string  | yes      | UUIDv4 chosen by payer. Used as on-chain key.              |
+| `payer`                     | string  | yes      | Checksummed EVM address.                                   |
+| `payee`                     | string  | yes      | Checksummed EVM address.                                   |
+| `amount_wei`                | int     | yes      | Amount in smallest denomination of `currency`.             |
+| `amount_usd`                | string  | no       | Optional USD equivalent at request time, decimal as string.|
+| `currency`                  | string  | yes      | `"ETH"`, `"USDC"`, `"USDT"`, etc.                          |
+| `chain_id`                  | int     | yes      | EIP-155 chain ID. `1` = mainnet, `8453` = Base, etc.       |
+| `timeout_blocks`            | int     | yes      | Blocks after `created_at` before payee can no longer claim.|
+| `challenge_period_blocks`   | int     | yes      | Blocks after `timeout_blocks` before payer can refund.     |
+| `description`               | string  | no       | Free-form human-readable.                                  |
+| `metadata`                  | object  | no       | Arbitrary JSON object — protocol-opaque.                   |
+| `created_at`                | float   | yes      | Unix epoch seconds, set by payer at request time.          |
+| `status`                    | string  | yes      | Local mirror of on-chain state. See §4.                    |
+
+### 2.1 Wire encoding
+
+```python
+json.dumps(d, sort_keys=True, separators=(',', ':'))
+```
+
+`sort_keys=True` and the tight separators give a byte-for-byte canonical encoding. Any payload that round-trips through `from_dict()` → `to_json()` produces identical bytes.
+
+### 2.2 Content hash
+
+```
+content_hash = "0x" + sha256(canonical_json).hexdigest()
+```
+
+`content_hash` is computed over **all fields except `created_at` and `status`**. Rationale: those two are instance-time / mutable. Two `PaymentRequest` objects representing the same payment intent (same `request_id`, payer, payee, amount, terms, metadata) MUST produce the same `content_hash` regardless of when they were instantiated or what their current local status is.
+
+For replay protection, agents SHOULD use `request_id` (UUID), not `content_hash`.
+
+## 3. Escrow contract — `AgentEscrow.sol`
+
+The `payer` calls `createPayment(request_id, payee, timeout_blocks, challenge_period)` with `msg.value = amount_wei`. Funds are held by the contract until one of:
+
+- `confirmPayment(request_id)` — released to `payee`. Callable only by `payer`.
+- `requestRefund(request_id)` — returned to `payer`. Callable only by `payer` AND only after `created_at + timeout_blocks + challenge_period`.
+- `cancelPayment(request_id)` — returned to `payer`. Callable only by `payer` AND only while still in `LOCKED`.
+
+Events emitted: `PaymentCreated`, `PaymentReleased`, `PaymentRefunded`. ABI mirrored in [`src/payment_protocol.py`](../src/payment_protocol.py) → `ESCROW_ABI`.
+
+## 4. State machine
+
+```
+                       createPayment()
+                  ┌────────────────────┐
+                  ▼                    │
+         ┌────────────────┐            │
+   ┌────▶│    PENDING     │            │
+   │     │  (request only)│            │
+   │     └────────┬───────┘            │
+   │              │ funds locked       │
+   │              ▼                    │
+   │     ┌────────────────┐            │
+   │     │     LOCKED     │            │
+   │     └────────┬───────┘            │
+   │              │                    │
+   │              ├──── confirmPayment()──▶ ┌───────────┐
+   │              │                         │  RELEASED  │
+   │              │                         └───────────┘
+   │              │
+   │              ├──── cancelPayment() ──▶ ┌────────────┐
+   │              │                         │  CANCELLED │
+   │              │                         └────────────┘
+   │              │
+   │              │ timeout_blocks +
+   │              │ challenge_period
+   │              │ elapsed
+   │              ▼
+   │     ┌────────────────┐  requestRefund()  ┌────────────┐
+   └─────│    EXPIRED     │ ─────────────────▶│  REFUNDED  │
+         └────────────────┘                   └────────────┘
+```
+
+| state      | transitions to                                    | trigger                                               |
+| ---------- | ------------------------------------------------- | ----------------------------------------------------- |
+| PENDING    | LOCKED                                            | `createPayment()` succeeds on-chain                   |
+| LOCKED     | RELEASED, CANCELLED, EXPIRED                      | `confirmPayment()`, `cancelPayment()`, time elapses   |
+| EXPIRED    | REFUNDED                                          | `requestRefund()` after challenge period              |
+| RELEASED, REFUNDED, CANCELLED | (terminal)                            | —                                                     |
+
+`PaymentState` enum mirrors this in `src/payment_protocol.py`.
+
+## 5. Lifecycle (happy path)
+
+```
+Agent A (payer)                Escrow                  Agent B (payee)
+     │                            │                            │
+     │   PaymentRequest (JSON) ───┼──────────────────────────▶ │
+     │                            │                            │
+     │   createPayment{value}     │                            │
+     │ ───────────────────────────▶                            │
+     │                            │ funds locked               │
+     │                            │   PaymentCreated ────────▶ │
+     │                            │                            │
+     │                            │       (B does the work)    │
+     │                            │ ◀───────────────────────── │
+     │                            │      delivery / proof      │
+     │                            │                            │
+     │   confirmPayment           │                            │
+     │ ───────────────────────────▶                            │
+     │                            │ funds released             │
+     │                            │   PaymentReleased ───────▶ │
+     │                            │                            │
+```
+
+## 6. Lifecycle (refund path)
+
+```
+Agent A (payer)                Escrow                  Agent B (payee)
+     │                            │                            │
+     │   createPayment{value}     │                            │
+     │ ───────────────────────────▶                            │
+     │                            │ funds locked               │
+     │                            │                            │
+     │                            │  (B disappears,            │
+     │                            │   never confirms)          │
+     │                            │                            │
+     │                            │  timeout_blocks elapse     │
+     │                            │  state → EXPIRED            │
+     │                            │                            │
+     │                            │  challenge_period elapses  │
+     │                            │                            │
+     │   requestRefund            │                            │
+     │ ───────────────────────────▶                            │
+     │                            │ funds returned             │
+     │                            │   PaymentRefunded          │
+     │ ◀────────────────────────── │                            │
+```
+
+## 7. Multi-chain considerations
+
+`chain_id` (EIP-155) MUST be set in every `PaymentRequest`. Receivers MUST reject any request whose `chain_id` doesn't match the chain their escrow is deployed on.
+
+`currency` is independent of `chain_id` — e.g. USDC on Base (`chain_id=8453`) vs USDC on Ethereum mainnet (`chain_id=1`) are different settlement instruments. Agents MUST explicitly set both.
+
+For non-EVM chains (Solana, Stellar, etc.) the wire format is reusable but the escrow contract is chain-specific and outside this protocol's scope. Future versions will extend `chain_id` to a CAIP-2 string (e.g. `"eip155:8453"`, `"solana:mainnet"`).
+
+## 8. Backwards-compat notes (vs. earlier drafts)
+
+- `content_hash` previously included `created_at`, which made the hash time-sensitive and broke determinism tests. v1.0 excludes `created_at` and `status` from the hash. Agents written against pre-v1.0 hashes MUST recompute on upgrade.
+- `parse_wei("N wei")` previously returned `N × 10^18` due to a case-mismatch in the unit dictionary. v1.0 fixes this to return `N` exactly. Audit any internal call sites that relied on the broken behavior.
+
+## 9. Future work
+
+- **CAIP-2 chain identifiers** for non-EVM networks (issue: TBD).
+- **MPP session adapter** for high-frequency micro-payments under a budget cap (tracked in [#17](https://github.com/kcolbchain/switchboard/issues/17)).
+- **A2A discovery** — how does Agent A know Agent B's address and accepted currencies? Out of scope for v1.0; consider `.well-known/agent-payment.json`.

--- a/src/payment_protocol.py
+++ b/src/payment_protocol.py
@@ -75,9 +75,22 @@ class PaymentRequest:
         return cls(**d)
 
     def content_hash(self) -> str:
-        """Calculate content-based hash for integrity check"""
+        """Calculate content-based hash for integrity check.
+
+        Excludes ``created_at`` (instance-time metadata) and ``status``
+        (mutable state) so two PaymentRequest objects representing the
+        same payment intent always hash identically. Any consumer doing
+        replay-protection should use ``request_id`` (UUID) for that —
+        not the content hash.
+        """
+        d = asdict(self)
+        if self.amount_usd is not None:
+            d['amount_usd'] = str(self.amount_usd)
+        d.pop('created_at', None)
+        d.pop('status', None)
+        canonical = json.dumps(d, sort_keys=True, separators=(',', ':'))
         h = hashlib.sha256()
-        h.update(self.to_json().encode('utf-8'))
+        h.update(canonical.encode('utf-8'))
         return "0x" + h.hexdigest()
 
 
@@ -505,12 +518,15 @@ def parse_wei(amount: str) -> int:
         num_str = parts[0]
         currency = "ETH"
     
+    # Keys uppercase so .upper() always matches; "wei" was previously
+    # lowercase which silently fell through to the ETH default and
+    # multiplied wei amounts by 10**18.
     multiplier = {
         "ETH": 10**18,
-        "wei": 1,
+        "WEI": 1,
         "KETH": 10**21,
     }.get(currency.upper(), 10**18)
-    
+
     return int(Decimal(num_str) * Decimal(multiplier))
 
 

--- a/tests/test_payment_protocol.py
+++ b/tests/test_payment_protocol.py
@@ -45,6 +45,19 @@ class MockAccount:
 
 # ─── Mock Contract ─────────────────────────────────────────────────────────
 
+class MockEvents:
+    """Stub for contract.events() — switchboard does not subscribe to events
+    in the unit-test surface (event monitoring is integration-tested elsewhere)."""
+    def PaymentCreated(self):
+        return MagicMock()
+
+    def PaymentReleased(self):
+        return MagicMock()
+
+    def PaymentRefunded(self):
+        return MagicMock()
+
+
 class MockContract:
     def __init__(self):
         self.address = "0x1234567890123456789012345678901234567890"
@@ -53,7 +66,7 @@ class MockContract:
     def functions(self):
         return MockContractFunctions(self)
 
-    def/events(self):
+    def events(self):
         return MockEvents()
 
 


### PR DESCRIPTION
## Summary

Closes #2.

Three concrete things, all grounded in the actual code:

### 1. New RFC-style spec at `docs/agent-payment-protocol.md`

Formalizes what was implicit in `src/payment_protocol.py`:

- Every `PaymentRequest` field with type, required-ness, and meaning
- Canonical wire encoding (`sort_keys=True` + tight separators) so the JSON is byte-deterministic
- `content_hash` semantics — excludes `created_at` and `status` so two requests for the same payment intent hash identically
- State-machine + lifecycle diagrams (happy path + refund path)
- Multi-chain section (current: EIP-155 `chain_id`; future: CAIP-2 for non-EVM)
- Backwards-compat notes for the two behavior changes below

### 2. Fix `content_hash` determinism in `src/payment_protocol.py`

Previously the hash included `created_at` (Unix epoch from `time.time()`), so two `PaymentRequest` objects with identical payment data but different instantiation times produced different hashes. That contradicted the docstring's "content-based hash for integrity check" promise.

New behavior: `content_hash` excludes `created_at` and `status`. For replay protection, agents should use `request_id` (UUID) — that's what it's there for.

### 3. Fix `parse_wei("N wei")` in `src/payment_protocol.py`

```python
multiplier = {
    "ETH": 10**18,
    "wei": 1,        # ← lowercase, .upper() returns "WEI", falls through to default
    "KETH": 10**21,
}.get(currency.upper(), 10**18)
```

`parse_wei("1000000000000000000 wei")` was returning `10^36`, not `10^18`. Fix: uppercase the dictionary keys.

### 4. Make `tests/test_payment_protocol.py` collectible

The file had `def/events(self):` (literal `/` in a method name) on line 56, which made the whole file a `SyntaxError` and prevented `pytest` from collecting any of the 10 tests in it. Fixed and added the missing `MockEvents` stub the file referenced.

## Test results

```
$ python -m pytest tests/ --ignore=tests/test_nonce_manager.py
50 passed in 0.25s
```

`test_nonce_manager.py` has a pre-existing missing-dep issue (`sortedcontainers` not in any requirements file) that's outside this PR's scope.

## What this PR does NOT cover

Issue #2 mentions "multi-chain support" as a goal. v1.0 of the spec explicitly captures EIP-155 `chain_id` and flags CAIP-2 chain identifiers as future work in §7 / §9. Implementing actual non-EVM settlement (Solana, Stellar) is a separate larger PR — happy to follow up if you want a v1.1 design proposal.