### PR TITLE
build: scaffold pyproject.toml — release-ready for PyPI as `switchboard-agents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,23 @@ Open issues with [`good first issue`](https://github.com/kcolbchain/switchboard/
 ## Install
 
 ```bash
-pip install -e .
+pip install switchboard-agents
 # optional, for ZAP binary wire:
+pip install 'switchboard-agents[zap]'
+# or, pinning to the upstream luxfi/zap python bindings directly:
 pip install 'luxfi-zap @ git+https://github.com/luxfi/zap@main#subdirectory=python'
 ```
 
+Or, for local development:
+
+```bash
+git clone https://github.com/kcolbchain/switchboard && cd switchboard
+pip install -e '.[dev]'
+```
+
 Python 3.11+. Tests: `pytest tests/`.
+
+> The PyPI distribution name is `switchboard-agents` (bare `switchboard` on PyPI is an unrelated WSGI library). The Python import name remains `import switchboard`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,85 @@
+[project]
+name = "switchboard-agents"
+version = "0.1.0"
+description = "Programmable payments for AI agents — HTTP/402, on-chain escrow, ZAP binary wire, gas budgets, nonce safety."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+    { name = "Abhishek Krishna", email = "invokerkrishna@gmail.com" },
+]
+keywords = [
+    "ai-agents",
+    "agent-payments",
+    "agent-to-agent",
+    "x402",
+    "escrow",
+    "zap",
+    "blockchain",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "sortedcontainers>=2.4.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.23.0",
+    "ruff>=0.8.0",
+    "black>=23.0.0",
+]
+web3 = [
+    "web3>=6.11.0",
+    "eth-account>=0.10.0",
+]
+zap = [
+    "zap-py",
+]
+
+[project.urls]
+Homepage = "https://kcolbchain.com"
+Documentation = "https://github.com/kcolbchain/switchboard#readme"
+Repository = "https://github.com/kcolbchain/switchboard"
+Issues = "https://github.com/kcolbchain/switchboard/issues"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["switchboard"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/switchboard",
+    "/src",
+    "/contracts",
+    "/tests",
+    "/README.md",
+    "/LICENSE",
+    "/CONTRIBUTING.md",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-v --tb=short"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "B", "C4", "UP"]
+ignore = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,18 @@ keywords = [
     "blockchain",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Office/Business :: Financial",
 ]
 dependencies = [
     "sortedcontainers>=2.4.0",
@@ -46,10 +51,12 @@ zap = [
 ]
 
 [project.urls]
-Homepage = "https://kcolbchain.com"
+Homepage = "https://github.com/kcolbchain/switchboard"
 Documentation = "https://github.com/kcolbchain/switchboard#readme"
 Repository = "https://github.com/kcolbchain/switchboard"
+Source = "https://github.com/kcolbchain/switchboard"
 Issues = "https://github.com/kcolbchain/switchboard/issues"
+Changelog = "https://github.com/kcolbchain/switchboard/releases"
 
 [build-system]
 requires = ["hatchling"]

--- a/switchboard/__init__.py
+++ b/switchboard/__init__.py
@@ -1,0 +1,13 @@
+"""switchboard — programmable payments for AI agents.
+
+The shared payment substrate for agent-to-agent settlement: HTTP/402 middleware,
+on-chain escrow, ZAP binary wire, gas budgets, and reorg-safe nonce management.
+
+See https://github.com/kcolbchain/switchboard for full docs.
+"""
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+]


### PR DESCRIPTION
Adds the Python packaging skeleton so switchboard can be cut as 0.1.0
on PyPI.

## Distribution name

The bare `switchboard` name on PyPI is taken (Kyle Adams' WSGI
feature-flag library, on PyPI for years). This PR uses
**`switchboard-agents`** as the distribution name — least
keyword-stuffed of the available options, reads naturally in a sentence
(`pip install switchboard-agents`), aligns with the GitHub topics
already on the repo (`agent-payments`, `agent-to-agent`,
`ai-agents`).

Other options considered + rejected:
- `switchboard-x402` — locks us into one wire; we position as
  protocol-agnostic (x402 / MPP / AP2 / Circle / escrow).
- `agent-switchboard` — works but reads less naturally.
- `kcolb-switchboard` — `kcolb` is not a recognized term, hurts
  discovery.

The **import path stays unchanged**: `from switchboard import ...`
works as before. Only the PyPI distribution name differs from the
import name (same pattern as PyYAML/yaml, beautifulsoup4/bs4).

## What's in this PR

- `pyproject.toml` — hatchling backend, mirrors the flavor used by
  `kcolbchain/tesseract`.
- `switchboard/__init__.py` — minimal package marker exposing
  `__version__`.

Base dependency: `sortedcontainers` (used by `nonce_manager`).
`web3`/`eth-account` and `zap-py` are optional extras (`pip
install switchboard-agents[web3]`, `[zap]`) so the base install
stays slim.

## Build sanity-check

    python -m build --wheel
    → switchboard_agents-0.1.0-py3-none-any.whl

## Not in this PR (deferred)

- PyPI tag + upload — gated on owner OK on the distribution name.
- GitHub Actions release workflow that publishes on tag — will follow
  in a separate PR once the name is locked.

Closes nothing.