### PR TITLE
docs+tests: protocol v1.0 frozen test vectors (3 fixtures) + conformance suite

### DIFF
--- a/docs/agent-payment-protocol.md
+++ b/docs/agent-payment-protocol.md
@@ -168,7 +168,29 @@ For non-EVM chains (Solana, Stellar, etc.) the wire format is reusable but the e
 - `content_hash` previously included `created_at`, which made the hash time-sensitive and broke determinism tests. v1.0 excludes `created_at` and `status` from the hash. Agents written against pre-v1.0 hashes MUST recompute on upgrade.
 - `parse_wei("N wei")` previously returned `N × 10^18` due to a case-mismatch in the unit dictionary. v1.0 fixes this to return `N` exactly. Audit any internal call sites that relied on the broken behavior.
 
-## 9. Future work
+## 9. Test vectors
+
+Frozen fixtures live at [`tests/protocol_vectors/payment_request.v1.json`](../tests/protocol_vectors/payment_request.v1.json). They pin the canonicalization rule + `content_hash` for three representative payloads:
+
+| Fixture | Exercises |
+|---|---|
+| `fixture-01-minimal` | Only required fields. No `amount_usd`, no `description`, no `metadata`. |
+| `fixture-02-full-metadata` | Optional `amount_usd` Decimal, free-form `description`, nested `metadata` dict with arrays. |
+| `fixture-03-unicode-boundary` | Emoji, quote, backslash, newline in `description`; mainnet `chain_id=1`; `amount_wei` at 250 ETH magnitude. |
+
+Each fixture records:
+
+- `input` — the dict the implementation receives.
+- `wire_canonical_bytes` — the exact byte sequence `to_json()` MUST produce.
+- `hash_input_canonical_bytes` — the same canonicalization with `created_at` and `status` removed (the bytes that get fed to sha256).
+- `content_hash_sha256` — the resulting `0x`-prefixed sha256 hex digest.
+
+Other-language implementations of this protocol can pin against the same JSON file and assert the same hashes. The Python conformance test lives at [`tests/test_protocol_vectors.py`](../tests/test_protocol_vectors.py) and runs under `pytest`.
+
+Any change that affects the canonicalization (e.g. adding a new optional field, changing how `Decimal` is stringified, switching JSON library to one with different sorting semantics) MUST update the fixtures **and** the spec's protocol version. A breaking-change to canonicalization without a version bump is a silent fork.
+
+## 10. Future work
+
 
 - **CAIP-2 chain identifiers** for non-EVM networks (issue: TBD).
 - **MPP session adapter** for high-frequency micro-payments under a budget cap (tracked in [#17](https://github.com/kcolbchain/switchboard/issues/17)).

--- a/tests/protocol_vectors/payment_request.v1.json
+++ b/tests/protocol_vectors/payment_request.v1.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "1",
+  "protocol_version": "1.0",
+  "spec_source": "docs/agent-payment-protocol.md §2.1 wire encoding, §2.2 content hash",
+  "canonicalization_rule": "json.dumps(d, sort_keys=True, separators=(',', ':')); content_hash excludes created_at and status; amount_usd Decimal is stringified",
+  "note": "wire_canonical_bytes is the to_json() output used for transmission/signing. hash_input_canonical_bytes is the same encoding with created_at and status removed, hashed via sha256 to produce content_hash_sha256. Any conforming implementation MUST reproduce both byte sequences and the same content_hash from the input dict.",
+  "vectors": [
+    {
+      "name": "fixture-01-minimal",
+      "description": "Only required PaymentRequest fields. No amount_usd, no description, no metadata.",
+      "input": {
+        "version": "1.0",
+        "request_id": "00000000-0000-4000-8000-000000000001",
+        "payer": "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        "payee": "0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf",
+        "amount_wei": 1000000,
+        "amount_usd": null,
+        "currency": "USDC",
+        "chain_id": 8453,
+        "timeout_blocks": 100,
+        "challenge_period_blocks": 10,
+        "description": "",
+        "metadata": {},
+        "created_at": 1715600000.0,
+        "status": "pending"
+      },
+      "wire_canonical_bytes": "{\"amount_usd\":null,\"amount_wei\":1000000,\"chain_id\":8453,\"challenge_period_blocks\":10,\"created_at\":1715600000.0,\"currency\":\"USDC\",\"description\":\"\",\"metadata\":{},\"payee\":\"0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf\",\"payer\":\"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0\",\"request_id\":\"00000000-0000-4000-8000-000000000001\",\"status\":\"pending\",\"timeout_blocks\":100,\"version\":\"1.0\"}",
+      "hash_input_canonical_bytes": "{\"amount_usd\":null,\"amount_wei\":1000000,\"chain_id\":8453,\"challenge_period_blocks\":10,\"currency\":\"USDC\",\"description\":\"\",\"metadata\":{},\"payee\":\"0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf\",\"payer\":\"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0\",\"request_id\":\"00000000-0000-4000-8000-000000000001\",\"timeout_blocks\":100,\"version\":\"1.0\"}",
+      "content_hash_sha256": "0x429de3fad95f4aa72f0c3b665bf657072c440eb59ce4f036313f5344286277ef"
+    },
+    {
+      "name": "fixture-02-full-metadata",
+      "description": "Full optional fields: amount_usd Decimal, free-form description, nested metadata dict including arrays.",
+      "input": {
+        "version": "1.0",
+        "request_id": "00000000-0000-4000-8000-000000000002",
+        "payer": "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        "payee": "0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf",
+        "amount_wei": 50000000,
+        "amount_usd": "50.00",
+        "currency": "USDC",
+        "chain_id": 8453,
+        "timeout_blocks": 1200,
+        "challenge_period_blocks": 50,
+        "description": "Multi-source research bundle: 3 paid x402 endpoints",
+        "metadata": {
+          "work_uri": "ipfs://bafyreiabcdef",
+          "work_hash": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "extensions": [
+            "walrus-blob-receipt-v1",
+            "kite-quikt-v0.4"
+          ]
+        },
+        "created_at": 1715600000.0,
+        "status": "pending"
+      },
+      "wire_canonical_bytes": "{\"amount_usd\":\"50.00\",\"amount_wei\":50000000,\"chain_id\":8453,\"challenge_period_blocks\":50,\"created_at\":1715600000.0,\"currency\":\"USDC\",\"description\":\"Multi-source research bundle: 3 paid x402 endpoints\",\"metadata\":{\"extensions\":[\"walrus-blob-receipt-v1\",\"kite-quikt-v0.4\"],\"work_hash\":\"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\",\"work_uri\":\"ipfs://bafyreiabcdef\"},\"payee\":\"0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf\",\"payer\":\"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0\",\"request_id\":\"00000000-0000-4000-8000-000000000002\",\"status\":\"pending\",\"timeout_blocks\":1200,\"version\":\"1.0\"}",
+      "hash_input_canonical_bytes": "{\"amount_usd\":\"50.00\",\"amount_wei\":50000000,\"chain_id\":8453,\"challenge_period_blocks\":50,\"currency\":\"USDC\",\"description\":\"Multi-source research bundle: 3 paid x402 endpoints\",\"metadata\":{\"extensions\":[\"walrus-blob-receipt-v1\",\"kite-quikt-v0.4\"],\"work_hash\":\"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\",\"work_uri\":\"ipfs://bafyreiabcdef\"},\"payee\":\"0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf\",\"payer\":\"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0\",\"request_id\":\"00000000-0000-4000-8000-000000000002\",\"timeout_blocks\":1200,\"version\":\"1.0\"}",
+      "content_hash_sha256": "0xde171e316e521a336a5fc8a65fe0c063269aed8ea2e75336a3922e00142d1819"
+    },
+    {
+      "name": "fixture-03-unicode-boundary",
+      "description": "Boundary: emoji + quote + backslash + newline in description; chain_id=1 mainnet; amount_wei at 250 ETH magnitude.",
+      "input": {
+        "version": "1.0",
+        "request_id": "00000000-0000-4000-8000-000000000003",
+        "payer": "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        "payee": "0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf",
+        "amount_wei": 250000000000000000000,
+        "amount_usd": null,
+        "currency": "ETH",
+        "chain_id": 1,
+        "timeout_blocks": 21600,
+        "challenge_period_blocks": 720,
+        "description": "Édge-case: emoji 🦊, quote \"x\", backslash \\, newline\nhere.",
+        "metadata": {
+          "note": "tests JSON escaping + unicode sorting"
+        },
+        "created_at": 1715600000.0,
+        "status": "pending"
+      },
+      "wire_canonical_bytes": "{\"amount_usd\":null,\"amount_wei\":250000000000000000000,\"chain_id\":1,\"challenge_period_blocks\":720,\"created_at\":1715600000.0,\"currency\":\"ETH\",\"description\":\"\\u00c9dge-case: emoji \\ud83e\\udd8a, quote \\\"x\\\", backslash \\\\, newline\\nhere.\",\"metadata\":{\"note\":\"tests JSON escaping + unicode sorting\"},\"payee\":\"0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf\",\"payer\":\"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0\",\"request_id\":\"00000000-0000-4000-8000-000000000003\",\"status\":\"pending\",\"timeout_blocks\":21600,\"version\":\"1.0\"}",
+      "hash_input_canonical_bytes": "{\"amount_usd\":null,\"amount_wei\":250000000000000000000,\"chain_id\":1,\"challenge_period_blocks\":720,\"currency\":\"ETH\",\"description\":\"\\u00c9dge-case: emoji \\ud83e\\udd8a, quote \\\"x\\\", backslash \\\\, newline\\nhere.\",\"metadata\":{\"note\":\"tests JSON escaping + unicode sorting\"},\"payee\":\"0xC504Fd656330A823C3ffcBAB048c05cF45F60Bdf\",\"payer\":\"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0\",\"request_id\":\"00000000-0000-4000-8000-000000000003\",\"timeout_blocks\":21600,\"version\":\"1.0\"}",
+      "content_hash_sha256": "0x198870cf93763105eaca9250ce73227e1017e687418737577765cece33f94392"
+    }
+  ]
+}

--- a/tests/test_protocol_vectors.py
+++ b/tests/test_protocol_vectors.py
@@ -1,0 +1,79 @@
+"""
+Conformance tests for the agent-to-agent payment protocol wire encoding +
+content hash.
+
+Loads frozen fixtures from `tests/protocol_vectors/payment_request.v1.json`
+and verifies that the current `PaymentRequest` implementation reproduces:
+
+  - the exact `wire_canonical_bytes` from `to_json()`
+  - the exact `hash_input_canonical_bytes` (canonical bytes minus
+    `created_at` / `status`)
+  - the exact `content_hash_sha256` from `content_hash()`
+
+A failure here means the wire format has drifted from v1.0 of the spec
+(see `docs/agent-payment-protocol.md` §2.1 and §2.2). That's a breaking
+change for cross-language implementations and should be reflected in a
+protocol version bump.
+
+Other language implementations of this protocol (e.g. a Rust client, a
+TypeScript client) can pin against the same JSON fixtures and assert the
+same hashes — that's the point of having frozen test vectors.
+
+Run with:
+  pytest tests/test_protocol_vectors.py -v
+"""
+
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from payment_protocol import PaymentRequest  # noqa: E402
+
+
+FIXTURES = Path(__file__).resolve().parent / "protocol_vectors" / "payment_request.v1.json"
+
+
+def _load_vectors():
+    return json.loads(FIXTURES.read_text(encoding="utf-8"))
+
+
+def _build_request(d: dict) -> PaymentRequest:
+    """Rebuild a PaymentRequest from the JSON fixture's `input` dict."""
+    d = dict(d)
+    if d.get("amount_usd") is not None:
+        d["amount_usd"] = Decimal(d["amount_usd"])
+    return PaymentRequest(**d)
+
+
+@pytest.fixture(scope="module")
+def vectors():
+    return _load_vectors()
+
+
+def test_protocol_version_matches(vectors):
+    assert vectors["protocol_version"] == "1.0"
+
+
+@pytest.mark.parametrize("fixture", _load_vectors()["vectors"], ids=lambda f: f["name"])
+def test_wire_canonical_bytes(fixture):
+    req = _build_request(fixture["input"])
+    assert req.to_json() == fixture["wire_canonical_bytes"]
+
+
+@pytest.mark.parametrize("fixture", _load_vectors()["vectors"], ids=lambda f: f["name"])
+def test_content_hash(fixture):
+    req = _build_request(fixture["input"])
+    assert req.content_hash() == fixture["content_hash_sha256"]
+
+
+@pytest.mark.parametrize("fixture", _load_vectors()["vectors"], ids=lambda f: f["name"])
+def test_round_trip_via_from_dict(fixture):
+    """`from_dict(to_dict(req))` MUST produce a request that hashes identically."""
+    req1 = _build_request(fixture["input"])
+    req2 = PaymentRequest.from_dict(req1.to_dict())
+    assert req2.content_hash() == fixture["content_hash_sha256"]
+    assert req2.to_json() == fixture["wire_canonical_bytes"]


### PR DESCRIPTION
Follow-up to #25, as floated in the merge thread.

## What

Adds `tests/protocol_vectors/payment_request.v1.json` with three frozen fixtures that pin the canonicalization rule + `content_hash` for representative `PaymentRequest` payloads:

- **fixture-01-minimal** — only required fields. No `amount_usd`, no `description`, no `metadata`.
- **fixture-02-full-metadata** — optional `amount_usd` Decimal, free-form `description`, nested `metadata` dict with arrays.
- **fixture-03-unicode-boundary** — emoji / quote / backslash / newline in description; mainnet `chain_id=1`; `amount_wei` at 250 ETH magnitude.

Each fixture records:

- `input` — the dict the implementation receives.
- `wire_canonical_bytes` — exact byte sequence `to_json()` MUST produce.
- `hash_input_canonical_bytes` — same canonicalization with `created_at` + `status` removed (the bytes fed to sha256).
- `content_hash_sha256` — resulting `0x`-prefixed sha256 hex digest.

Adds `tests/test_protocol_vectors.py` as the Python conformance test (10 cases: protocol-version check, 3× wire-bytes, 3× content_hash, 3× round-trip-through-from_dict).

Adds a §9 "Test vectors" section to `docs/agent-payment-protocol.md` explaining the rule for cross-language pinning. Renumbered §9 "Future work" → §10.

## Why

The spec at §2.1 currently claims "byte-deterministic canonical JSON." That's true but unverifiable without frozen vectors — there's no concrete test other-language implementations (Rust, TypeScript, Go) can diff against. With this PR, anyone implementing the protocol in another language can:

1. Read `payment_request.v1.json`.
2. Reconstruct each `input` in their language.
3. Run their canonicalization.
4. Assert their output bytes match `wire_canonical_bytes`.
5. Hash the input minus `created_at`/`status` with sha256.
6. Assert the hex matches `content_hash_sha256`.

A failure at any step means their implementation has diverged from v1.0 — caught at the boundary, not at the next inter-op test.

## Verified

```bash
$ pytest tests/test_protocol_vectors.py -v
  ...
  10 passed in 0.02s
```

All three fixtures' `content_hash` values were computed from the current `payment_protocol.py` implementation at `628f412` (post-#25 merge):

| Fixture | `content_hash` |
|---|---|
| fixture-01-minimal | `0x429de3fad95f4aa72f0c3b665bf657072c440eb59ce4f036313f5344286277ef` |
| fixture-02-full-metadata | `0xde171e316e521a336a5fc8a65fe0c063269aed8ea2e75336a3922e00142d1819` |
| fixture-03-unicode-boundary | `0x198870cf93763105eaca9250ce73227e1017e687418737577765cece33f94392` |

## Future-protecting note

Any change that affects the canonicalization (adding a new optional field, changing how `Decimal` is stringified, etc.) MUST update the fixtures **and** the spec's protocol version. The spec note in §9 makes that obligation explicit so a future contributor can't silently fork by accident.

Happy to also add a Rust skeleton (`tests/rust/`) or TypeScript skeleton (`tests/ts/`) that loads the same fixtures and asserts the same hashes, if you want a multi-language conformance suite sooner rather than later.

— @kite-builds