### PR TITLE
Add A2A x402 adapter

### DIFF
--- a/docs/adapters/a2a-x402.md
+++ b/docs/adapters/a2a-x402.md
@@ -1,0 +1,128 @@
+# A2A x402 adapter
+
+Switchboard normally represents payment challenges as `PaymentOffer` objects and
+payment submissions as `PaymentProof` objects. The Google
+`google-agentic-commerce/a2a-x402` extension carries the same lifecycle inside
+A2A `message/send` JSON metadata:
+
+- `x402.payment.status: payment-required`
+- `x402.payment.required`: an `x402PaymentRequiredResponse` with accepted
+  `PaymentRequirements`
+- `x402.payment.status: payment-submitted`
+- `x402.payment.payload`: the signed x402 payment payload
+
+`switchboard.adapters.a2a_x402` is a dependency-free bridge between those two
+representations.
+
+## Offer to A2A request
+
+```python
+from switchboard.adapters.a2a_x402 import to_a2a_request
+from switchboard.x402_middleware import PaymentOffer, PaymentScheme
+
+request = to_a2a_request(
+    PaymentOffer(
+        amount_wei=1_000_000,
+        currency="USDC",
+        recipient="0x1111111111111111111111111111111111111111",
+        chain_id=8453,
+        scheme=PaymentScheme.EXACT,
+        description="Generate one image",
+        endpoint="/v1/images",
+        nonce="offer-nonce-1",
+    )
+)
+```
+
+The returned `request` is a standalone A2A `message/send` JSON-RPC body. Its
+message metadata contains:
+
+```json
+{
+  "x402.payment.status": "payment-required",
+  "x402.payment.required": {
+    "x402Version": 1,
+    "accepts": [
+      {
+        "scheme": "exact",
+        "network": "base",
+        "payTo": "0x1111111111111111111111111111111111111111",
+        "maxAmountRequired": "1000000",
+        "asset": "USDC",
+        "resource": "/v1/images",
+        "description": "Generate one image",
+        "mimeType": "application/json"
+      }
+    ],
+    "error": "Payment required"
+  }
+}
+```
+
+If you already construct A2A messages elsewhere, you can copy only the metadata
+block into your existing message.
+
+## A2A response to proof
+
+```python
+from switchboard.adapters.a2a_x402 import from_a2a_response
+
+proof = from_a2a_response(
+    {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "taskId": "task-123",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "Here is the payment authorization."}],
+                "metadata": {
+                    "x402.payment.status": "payment-submitted",
+                    "x402.payment.payload": {
+                        "x402Version": 1,
+                        "scheme": "exact",
+                        "network": "base",
+                        "payload": {
+                            "signature": "0xabab...",
+                            "authorization": {
+                                "from": "0x2222222222222222222222222222222222222222",
+                                "to": "0x1111111111111111111111111111111111111111",
+                                "value": "1000000",
+                                "nonce": "proof-nonce-1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+)
+```
+
+`proof` is a Switchboard `PaymentProof` that can be passed to existing
+Switchboard verification and accounting code.
+
+## Supported networks
+
+The adapter maps common x402 network names to EIP-155 chain IDs:
+
+| x402 network | Chain ID |
+| --- | ---: |
+| `ethereum`, `mainnet`, `eth` | 1 |
+| `base` | 8453 |
+| `base-sepolia` | 84532 |
+| `sepolia` | 11155111 |
+| `eip155:<id>` | `<id>` |
+
+Unknown Switchboard chain IDs are emitted as `eip155:<id>` in A2A requests.
+
+## Notes and limits
+
+- The adapter is pure encoding/decoding; it does not sign, verify, or settle
+  payments.
+- It intentionally does not depend on `a2a-sdk`, `x402`, or `pydantic` so it can
+  run in minimal Switchboard clients.
+- When the A2A payload has not been settled yet and no facilitator transaction
+  hash is available, the adapter uses the signed payload `signature` as the
+  proof reference. If a `transaction`, `txHash`, or `tx_hash` field exists, that
+  settled transaction reference is preferred.

--- a/switchboard/adapters/__init__.py
+++ b/switchboard/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapters that bridge Switchboard payment envelopes to external protocols."""
+
+from .a2a_x402 import from_a2a_response, to_a2a_request
+
+__all__ = ["from_a2a_response", "to_a2a_request"]

--- a/switchboard/adapters/a2a_x402.py
+++ b/switchboard/adapters/a2a_x402.py
@@ -1,0 +1,247 @@
+"""A2A x402 adapter for Switchboard payment envelopes.
+
+The google-agentic-commerce/a2a-x402 extension carries payment requests and
+payment submissions as JSON metadata on A2A tasks/messages. Switchboard's core
+payment middleware uses small Python dataclasses (``PaymentOffer`` and
+``PaymentProof``) and can additionally encode them as ZAP binary messages.
+
+This module is intentionally dependency-free: it maps between the stable JSON
+shape documented by the A2A x402 spec and Switchboard's existing dataclasses
+without importing the A2A SDK, pydantic models, or x402 facilitator libraries.
+That keeps the adapter usable in clients that only need to bridge wire formats.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from switchboard.x402_middleware import PaymentOffer, PaymentProof
+
+PAYMENT_STATUS_KEY = "x402.payment.status"
+PAYMENT_REQUIRED_KEY = "x402.payment.required"
+PAYMENT_PAYLOAD_KEY = "x402.payment.payload"
+PAYMENT_REQUIRED = "payment-required"
+PAYMENT_SUBMITTED = "payment-submitted"
+
+_CHAIN_TO_NETWORK = {
+    1: "ethereum",
+    8453: "base",
+    84532: "base-sepolia",
+    11155111: "sepolia",
+}
+_NETWORK_TO_CHAIN = {network: chain_id for chain_id, network in _CHAIN_TO_NETWORK.items()}
+_NETWORK_TO_CHAIN.update({"mainnet": 1, "eth": 1})
+
+
+def to_a2a_request(offer: PaymentOffer) -> dict[str, Any]:
+    """Convert a Switchboard ``PaymentOffer`` to standalone A2A x402 JSON.
+
+    The returned object is a complete ``message/send`` JSON-RPC request body
+    whose message metadata contains ``x402.payment.status`` and
+    ``x402.payment.required``. Callers that already build their own A2A message
+    can reuse ``request["params"]["message"]["metadata"]`` directly.
+    """
+
+    requirements = _offer_to_payment_requirements(offer)
+    return {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "agent",
+                "parts": [
+                    {
+                        "kind": "text",
+                        "text": offer.description or "Payment required.",
+                    }
+                ],
+                "metadata": {
+                    PAYMENT_STATUS_KEY: PAYMENT_REQUIRED,
+                    PAYMENT_REQUIRED_KEY: {
+                        "x402Version": 1,
+                        "accepts": [requirements],
+                        "error": "Payment required",
+                    },
+                },
+            }
+        },
+    }
+
+
+def from_a2a_response(payload: Mapping[str, Any]) -> PaymentProof:
+    """Extract a Switchboard ``PaymentProof`` from A2A x402 response JSON.
+
+    ``payload`` may be any of the common standalone-flow shapes:
+
+    - a full JSON-RPC ``message/send`` request body,
+    - an A2A ``message`` object,
+    - a metadata dict containing ``x402.payment.payload``, or
+    - the ``PaymentPayload`` object itself.
+
+    The adapter accepts both camelCase aliases from x402/a2a JSON and the
+    snake_case field names used by Python model dumps.
+    """
+
+    payment_payload = _extract_payment_payload(payload)
+    inner = _as_mapping(payment_payload.get("payload"), "payload")
+    authorization = _as_mapping(inner.get("authorization", {}), "payload.authorization")
+
+    network = _string(payment_payload.get("network"), "network")
+    chain_id = _chain_id_from_network(network)
+
+    payer = _first_string(
+        inner,
+        authorization,
+        keys=("payer", "from", "fromAddress", "from_address"),
+        field_name="payer/from",
+    )
+    amount = _first_int(
+        inner,
+        authorization,
+        keys=("amount", "value", "maxAmountRequired", "max_amount_required"),
+        field_name="amount/value",
+    )
+    tx_hash = _optional_first_string(
+        inner,
+        payment_payload,
+        keys=("txHash", "tx_hash", "transaction", "hash", "signature"),
+    ) or _synthetic_signature_reference(inner)
+    nonce = _optional_first_string(
+        inner,
+        authorization,
+        keys=("nonce", "paymentNonce", "payment_nonce"),
+    ) or ""
+
+    return PaymentProof(
+        tx_hash=tx_hash,
+        chain_id=chain_id,
+        payer=payer,
+        amount_wei=amount,
+        nonce=nonce,
+        timestamp=float(int(time.time())),
+    )
+
+
+def _offer_to_payment_requirements(offer: PaymentOffer) -> dict[str, Any]:
+    max_timeout = 600
+    if offer.expires_at is not None:
+        max_timeout = max(0, int(offer.expires_at - time.time()))
+
+    return {
+        "scheme": offer.scheme.value,
+        "network": _network_from_chain_id(offer.chain_id),
+        "payTo": offer.recipient,
+        "maxAmountRequired": str(offer.amount_wei),
+        "asset": offer.currency,
+        "resource": offer.endpoint or "/",
+        "description": offer.description,
+        "mimeType": "application/json",
+        "maxTimeoutSeconds": max_timeout,
+        "extra": {
+            "switchboard": {
+                "chainId": offer.chain_id,
+                "currency": offer.currency,
+                "nonce": offer.nonce,
+                "scheme": offer.scheme.value,
+            }
+        },
+    }
+
+
+def _extract_payment_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    current: Any = payload
+
+    if "params" in current:
+        current = _as_mapping(current["params"], "params").get("message", current)
+    if "message" in current:
+        current = current["message"]
+    if "metadata" in current:
+        current = _as_mapping(current["metadata"], "metadata")
+    if PAYMENT_PAYLOAD_KEY in current:
+        current = current[PAYMENT_PAYLOAD_KEY]
+
+    current = _as_mapping(current, PAYMENT_PAYLOAD_KEY)
+    if "payload" not in current:
+        raise ValueError("A2A x402 response is missing payment payload data")
+    return current
+
+
+def _network_from_chain_id(chain_id: int) -> str:
+    return _CHAIN_TO_NETWORK.get(chain_id, f"eip155:{chain_id}")
+
+
+def _chain_id_from_network(network: str) -> int:
+    if network in _NETWORK_TO_CHAIN:
+        return _NETWORK_TO_CHAIN[network]
+    if network.startswith("eip155:"):
+        return int(network.split(":", 1)[1])
+    raise ValueError(f"Unsupported x402 network: {network}")
+
+
+def _as_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    raise ValueError(f"{field_name} must be an object")
+
+
+def _string(value: Any, field_name: str) -> str:
+    if isinstance(value, str) and value:
+        return value
+    raise ValueError(f"{field_name} must be a non-empty string")
+
+
+def _first_string(
+    primary: Mapping[str, Any],
+    secondary: Mapping[str, Any],
+    *,
+    keys: tuple[str, ...],
+    field_name: str,
+) -> str:
+    value = _optional_first_string(primary, secondary, keys=keys)
+    if value is None:
+        raise ValueError(f"A2A x402 payload is missing {field_name}")
+    return value
+
+
+def _optional_first_string(
+    primary: Mapping[str, Any],
+    secondary: Mapping[str, Any],
+    *,
+    keys: tuple[str, ...],
+) -> str | None:
+    for mapping in (primary, secondary):
+        for key in keys:
+            value = mapping.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _first_int(
+    primary: Mapping[str, Any],
+    secondary: Mapping[str, Any],
+    *,
+    keys: tuple[str, ...],
+    field_name: str,
+) -> int:
+    for mapping in (primary, secondary):
+        for key in keys:
+            if key not in mapping:
+                continue
+            value = mapping[key]
+            if isinstance(value, int):
+                return value
+            if isinstance(value, str) and value.isdigit():
+                return int(value)
+    raise ValueError(f"A2A x402 payload is missing numeric {field_name}")
+
+
+def _synthetic_signature_reference(inner: Mapping[str, Any]) -> str:
+    """Return a stable proof reference when a facilitator tx is not present yet."""
+
+    signature = _optional_first_string(inner, {}, keys=("signature",))
+    if not signature:
+        raise ValueError("A2A x402 payload is missing txHash/transaction/signature")
+    return signature

--- a/switchboard/x402_middleware.py
+++ b/switchboard/x402_middleware.py
@@ -26,20 +26,22 @@ References:
     - EIP-7702 for smart account payments
 """
 
-import asyncio
-import hashlib
 import json
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from decimal import Decimal
-from typing import Optional, Dict, Any, Callable
 from enum import Enum
+from typing import TYPE_CHECKING, Any
 
 try:
     import aiohttp
     HAS_AIOHTTP = True
 except ImportError:
+    aiohttp = None
     HAS_AIOHTTP = False
+
+if TYPE_CHECKING:
+    import aiohttp as aiohttp_typing
 
 
 class PaymentScheme(Enum):
@@ -60,7 +62,7 @@ class PaymentOffer:
     description: str = ""
     endpoint: str = ""
     nonce: str = ""
-    expires_at: Optional[int] = None  # Unix timestamp
+    expires_at: int | None = None  # Unix timestamp
 
     @classmethod
     def from_header(cls, header_value: str, endpoint: str = "") -> "PaymentOffer":
@@ -129,13 +131,10 @@ class X402Middleware:
         payment_client,
         gas_tracker=None,
         max_payment_wei: int = 10**16,  # 0.01 ETH default cap
-        allowed_recipients: Optional[set] = None,
+        allowed_recipients: set | None = None,
         auto_pay: bool = True,
-        on_payment: Optional[Callable[[PaymentRecord], None]] = None,
+        on_payment: Callable[[PaymentRecord], None] | None = None,
     ):
-        if not HAS_AIOHTTP:
-            raise ImportError("aiohttp required: pip install aiohttp")
-
         self.payment_client = payment_client
         self.gas_tracker = gas_tracker
         self.max_payment_wei = max_payment_wei
@@ -145,9 +144,11 @@ class X402Middleware:
 
         self.payment_history: list[PaymentRecord] = []
         self.total_spent_wei: int = 0
-        self._session: Optional[aiohttp.ClientSession] = None
+        self._session: aiohttp_typing.ClientSession | None = None
 
-    async def _get_session(self) -> aiohttp.ClientSession:
+    async def _get_session(self) -> "aiohttp_typing.ClientSession":
+        if not HAS_AIOHTTP:
+            raise ImportError("aiohttp required: pip install aiohttp")
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
         return self._session
@@ -216,9 +217,9 @@ class X402Middleware:
         url: str,
         payload: Any = None,
         method: str = "POST",
-        headers: Optional[Dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
         **kwargs,
-    ) -> aiohttp.ClientResponse:
+    ) -> "aiohttp_typing.ClientResponse":
         """
         Make an HTTP request. If the server returns 402, automatically
         pay and retry with payment proof.
@@ -272,7 +273,7 @@ class X402Middleware:
 
     def get_spend_summary(self) -> dict:
         """Return summary of all payments made."""
-        by_endpoint: Dict[str, int] = {}
+        by_endpoint: dict[str, int] = {}
         for record in self.payment_history:
             by_endpoint[record.endpoint] = (
                 by_endpoint.get(record.endpoint, 0) + record.offer.amount_wei

--- a/tests/test_a2a_x402_adapter.py
+++ b/tests/test_a2a_x402_adapter.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import pytest
+
+from switchboard.adapters.a2a_x402 import (
+    PAYMENT_PAYLOAD_KEY,
+    PAYMENT_REQUIRED_KEY,
+    PAYMENT_STATUS_KEY,
+    from_a2a_response,
+    to_a2a_request,
+)
+from switchboard.x402_middleware import PaymentOffer, PaymentProof, PaymentScheme
+
+RECIPIENT = "0x1111111111111111111111111111111111111111"
+PAYER = "0x2222222222222222222222222222222222222222"
+SIGNATURE = "0x" + "ab" * 32
+
+
+def sample_offer() -> PaymentOffer:
+    return PaymentOffer(
+        amount_wei=1_000_000,
+        currency="USDC",
+        recipient=RECIPIENT,
+        chain_id=8453,
+        scheme=PaymentScheme.EXACT,
+        description="Generate one image",
+        endpoint="/v1/images",
+        nonce="offer-nonce-1",
+        expires_at=2_000_000_000,
+    )
+
+
+def sample_payment_payload() -> dict:
+    return {
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "base",
+        "payload": {
+            "signature": SIGNATURE,
+            "authorization": {
+                "from": PAYER,
+                "to": RECIPIENT,
+                "value": "1000000",
+                "validAfter": "0",
+                "validBefore": "2000000000",
+                "nonce": "proof-nonce-1",
+            },
+        },
+    }
+
+
+def test_to_a2a_request_places_payment_required_metadata():
+    request = to_a2a_request(sample_offer())
+
+    assert request["jsonrpc"] == "2.0"
+    assert request["method"] == "message/send"
+    metadata = request["params"]["message"]["metadata"]
+    assert metadata[PAYMENT_STATUS_KEY] == "payment-required"
+
+    required = metadata[PAYMENT_REQUIRED_KEY]
+    assert required["x402Version"] == 1
+    assert required["error"] == "Payment required"
+    assert len(required["accepts"]) == 1
+
+
+def test_to_a2a_request_maps_offer_to_payment_requirements():
+    request = to_a2a_request(sample_offer())
+    requirement = request["params"]["message"]["metadata"][PAYMENT_REQUIRED_KEY]["accepts"][0]
+
+    assert requirement["scheme"] == "exact"
+    assert requirement["network"] == "base"
+    assert requirement["payTo"] == RECIPIENT
+    assert requirement["maxAmountRequired"] == "1000000"
+    assert requirement["asset"] == "USDC"
+    assert requirement["resource"] == "/v1/images"
+    assert requirement["description"] == "Generate one image"
+    assert requirement["mimeType"] == "application/json"
+    assert requirement["extra"]["switchboard"]["chainId"] == 8453
+    assert requirement["extra"]["switchboard"]["nonce"] == "offer-nonce-1"
+
+
+def test_to_a2a_request_uses_eip155_network_for_unknown_chain():
+    offer = sample_offer()
+    offer.chain_id = 999999
+
+    requirement = to_a2a_request(offer)["params"]["message"]["metadata"][PAYMENT_REQUIRED_KEY][
+        "accepts"
+    ][0]
+
+    assert requirement["network"] == "eip155:999999"
+
+
+def test_from_a2a_response_accepts_full_jsonrpc_message_send_body():
+    response = {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "taskId": "task-123",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "Here is the payment authorization."}],
+                "metadata": {
+                    PAYMENT_STATUS_KEY: "payment-submitted",
+                    PAYMENT_PAYLOAD_KEY: sample_payment_payload(),
+                },
+            }
+        },
+    }
+
+    proof = from_a2a_response(response)
+
+    assert isinstance(proof, PaymentProof)
+    assert proof.tx_hash == SIGNATURE
+    assert proof.chain_id == 8453
+    assert proof.payer == PAYER
+    assert proof.amount_wei == 1_000_000
+    assert proof.nonce == "proof-nonce-1"
+
+
+def test_from_a2a_response_accepts_metadata_dict_directly():
+    proof = from_a2a_response({PAYMENT_PAYLOAD_KEY: sample_payment_payload()})
+
+    assert proof.tx_hash == SIGNATURE
+    assert proof.chain_id == 8453
+    assert proof.payer == PAYER
+
+
+def test_from_a2a_response_prefers_facilitator_transaction_reference_when_present():
+    payload = sample_payment_payload()
+    payload["payload"]["transaction"] = "0xsettled"
+
+    proof = from_a2a_response(payload)
+
+    assert proof.tx_hash == "0xsettled"
+
+
+def test_from_a2a_response_supports_eip155_networks_and_top_level_amounts():
+    payload = {
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "eip155:11155111",
+        "payload": {
+            "txHash": "0xabc123",
+            "payer": PAYER,
+            "amount": 42,
+            "nonce": "n1",
+        },
+    }
+
+    proof = from_a2a_response(payload)
+
+    assert proof.chain_id == 11155111
+    assert proof.tx_hash == "0xabc123"
+    assert proof.amount_wei == 42
+    assert proof.nonce == "n1"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"network": "base"}, "missing payment payload"),
+        ({"network": "unknown", "payload": {"signature": SIGNATURE}}, "Unsupported x402 network"),
+        ({"network": "base", "payload": {"signature": SIGNATURE}}, "missing payer/from"),
+        (
+            {"network": "base", "payload": {"signature": SIGNATURE, "payer": PAYER}},
+            "missing numeric amount/value",
+        ),
+    ],
+)
+def test_from_a2a_response_rejects_malformed_payloads(payload: dict, message: str):
+    with pytest.raises(ValueError, match=message):
+        from_a2a_response(payload)


### PR DESCRIPTION
## Summary

Implements a dependency-free `switchboard.adapters.a2a_x402` bridge for issue #29.

The adapter converts Switchboard payment envelopes to/from the standalone Google A2A x402 JSON metadata flow:

- `to_a2a_request(offer: PaymentOffer) -> dict`
  - emits an A2A `message/send` body with `x402.payment.status: payment-required`
  - includes an `x402.payment.required` response with `PaymentRequirements`
  - maps known Switchboard chain IDs to x402 networks (`base`, `base-sepolia`, `sepolia`, `ethereum`) and unknown chain IDs to `eip155:<id>`
- `from_a2a_response(payload: dict) -> PaymentProof`
  - accepts full JSON-RPC request bodies, A2A message objects, metadata dicts, or raw `PaymentPayload` objects
  - extracts payer, amount, nonce, network/chain ID, and transaction/signature reference into a Switchboard `PaymentProof`
- Adds `docs/adapters/a2a-x402.md` with an end-to-end usage example and supported network mapping
- Adds focused pytest coverage for request generation, response parsing, malformed payloads, network mapping, and transaction-reference precedence

## Validation

```bash
python3 -m venv .venv
.venv/bin/python -m pip install -e '.[dev]'
.venv/bin/python -m pytest tests/test_a2a_x402_adapter.py tests/test_x402_middleware.py -q
.venv/bin/python -m ruff check switchboard/adapters/a2a_x402.py tests/test_a2a_x402_adapter.py switchboard/x402_middleware.py
git diff --check
```

Result:

```text
25 passed
All checks passed!
```

I also ran the full test suite with `.venv/bin/python -m pytest -q`: this branch has 64 passed, 1 skipped, and 6 failures in `tests/test_nonce_manager.py`. Those nonce-manager failures are outside the adapter scope and are not touched by this PR.

## Note

While adding the adapter tests, importing `switchboard.x402_middleware` in an environment without optional `aiohttp` exposed an existing import-time annotation issue. I moved the optional dependency check to `_get_session()` so dataclasses and pure adapters can be imported without `aiohttp`, while actual HTTP usage still raises the same actionable `ImportError`.

Closes #29
