### PR TITLE
Add A2A x402 adapter

### DIFF
--- a/docs/adapters/a2a-x402.md
+++ b/docs/adapters/a2a-x402.md
@@ -1,128 +1,87 @@
 # A2A x402 adapter
 
-Switchboard normally represents payment challenges as `PaymentOffer` objects and
-payment submissions as `PaymentProof` objects. The Google
-`google-agentic-commerce/a2a-x402` extension carries the same lifecycle inside
-A2A `message/send` JSON metadata:
+`switchboard.adapters.a2a_x402` converts Switchboard payment envelopes to and
+from the JSON metadata used by the A2A x402 extension v0.1.
 
-- `x402.payment.status: payment-required`
-- `x402.payment.required`: an `x402PaymentRequiredResponse` with accepted
-  `PaymentRequirements`
-- `x402.payment.status: payment-submitted`
-- `x402.payment.payload`: the signed x402 payment payload
+The adapter is deliberately pure. It does not hold keys, sign transactions,
+verify signatures, call a facilitator, or settle payments. Those responsibilities
+stay with the wallet, facilitator, or Switchboard payment client.
 
-`switchboard.adapters.a2a_x402` is a dependency-free bridge between those two
-representations.
-
-## Offer to A2A request
+## Merchant: require payment
 
 ```python
 from switchboard.adapters.a2a_x402 import to_a2a_request
-from switchboard.x402_middleware import PaymentOffer, PaymentScheme
+from switchboard.x402_middleware import PaymentOffer
 
-request = to_a2a_request(
-    PaymentOffer(
-        amount_wei=1_000_000,
-        currency="USDC",
-        recipient="0x1111111111111111111111111111111111111111",
-        chain_id=8453,
-        scheme=PaymentScheme.EXACT,
-        description="Generate one image",
-        endpoint="/v1/images",
-        nonce="offer-nonce-1",
-    )
+offer = PaymentOffer(
+    amount_wei=48_240_000,
+    currency="0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
+    recipient="0xServerWalletAddressHere",
+    chain_id=8453,
+    description="Generate an image",
+    endpoint="https://api.example.com/generate-image",
 )
-```
 
-The returned `request` is a standalone A2A `message/send` JSON-RPC body. Its
-message metadata contains:
-
-```json
-{
-  "x402.payment.status": "payment-required",
-  "x402.payment.required": {
-    "x402Version": 1,
-    "accepts": [
-      {
-        "scheme": "exact",
-        "network": "base",
-        "payTo": "0x1111111111111111111111111111111111111111",
-        "maxAmountRequired": "1000000",
-        "asset": "USDC",
-        "resource": "/v1/images",
-        "description": "Generate one image",
-        "mimeType": "application/json"
-      }
-    ],
-    "error": "Payment required"
-  }
+metadata = {
+    "x402.payment.status": "payment-required",
+    "x402.payment.required": to_a2a_request(offer),
 }
 ```
 
-If you already construct A2A messages elsewhere, you can copy only the metadata
-block into your existing message.
+The generated `x402.payment.required` object follows the A2A x402 v0.1
+`x402PaymentRequiredResponse` shape:
 
-## A2A response to proof
+```json
+{
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "base",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
+      "payTo": "0xServerWalletAddressHere",
+      "maxAmountRequired": "48240000",
+      "resource": "https://api.example.com/generate-image",
+      "description": "Generate an image",
+      "mimeType": "application/json"
+    }
+  ]
+}
+```
+
+## Client: submit payment
+
+After the client signs and submits a payment, a Switchboard `PaymentProof` can
+be wrapped as A2A x402 `payment-submitted` metadata:
+
+```python
+from switchboard.adapters.a2a_x402 import to_a2a_submission
+
+metadata = to_a2a_submission(proof)
+```
+
+## Merchant: read receipt
+
+The adapter accepts final A2A x402 settlement receipts:
 
 ```python
 from switchboard.adapters.a2a_x402 import from_a2a_response
 
-proof = from_a2a_response(
-    {
-        "jsonrpc": "2.0",
-        "method": "message/send",
-        "params": {
-            "message": {
-                "taskId": "task-123",
-                "role": "user",
-                "parts": [{"kind": "text", "text": "Here is the payment authorization."}],
-                "metadata": {
-                    "x402.payment.status": "payment-submitted",
-                    "x402.payment.payload": {
-                        "x402Version": 1,
-                        "scheme": "exact",
-                        "network": "base",
-                        "payload": {
-                            "signature": "0xabab...",
-                            "authorization": {
-                                "from": "0x2222222222222222222222222222222222222222",
-                                "to": "0x1111111111111111111111111111111111111111",
-                                "value": "1000000",
-                                "nonce": "proof-nonce-1"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-)
+proof = from_a2a_response(task["status"]["message"]["metadata"])
 ```
 
-`proof` is a Switchboard `PaymentProof` that can be passed to existing
-Switchboard verification and accounting code.
+It also accepts direct `x402.payment.payload` envelopes from clients for
+middleware integrations that expose the signed payload before settlement.
 
-## Supported networks
+## Network mapping
 
-The adapter maps common x402 network names to EIP-155 chain IDs:
+Known networks are mapped to EVM chain ids:
 
-| x402 network | Chain ID |
+| A2A network | Chain id |
 | --- | ---: |
-| `ethereum`, `mainnet`, `eth` | 1 |
+| `ethereum` | 1 |
 | `base` | 8453 |
 | `base-sepolia` | 84532 |
-| `sepolia` | 11155111 |
-| `eip155:<id>` | `<id>` |
 
-Unknown Switchboard chain IDs are emitted as `eip155:<id>` in A2A requests.
-
-## Notes and limits
-
-- The adapter is pure encoding/decoding; it does not sign, verify, or settle
-  payments.
-- It intentionally does not depend on `a2a-sdk`, `x402`, or `pydantic` so it can
-  run in minimal Switchboard clients.
-- When the A2A payload has not been settled yet and no facilitator transaction
-  hash is available, the adapter uses the signed payload `signature` as the
-  proof reference. If a `transaction`, `txHash`, or `tx_hash` field exists, that
-  settled transaction reference is preferred.
+Unknown EVM chains are represented as `eip155:<chain_id>` and round-trip back
+to the same numeric chain id.

--- a/switchboard/adapters/__init__.py
+++ b/switchboard/adapters/__init__.py
@@ -1,5 +1,1 @@
-"""Adapters that bridge Switchboard payment envelopes to external protocols."""
-
-from .a2a_x402 import from_a2a_response, to_a2a_request
-
-__all__ = ["from_a2a_response", "to_a2a_request"]
+"""Adapters for external agent payment protocols."""

--- a/switchboard/adapters/a2a_x402.py
+++ b/switchboard/adapters/a2a_x402.py
@@ -1,247 +1,271 @@
-"""A2A x402 adapter for Switchboard payment envelopes.
+"""A2A x402 JSON adapter for Switchboard payment envelopes.
 
-The google-agentic-commerce/a2a-x402 extension carries payment requests and
-payment submissions as JSON metadata on A2A tasks/messages. Switchboard's core
-payment middleware uses small Python dataclasses (``PaymentOffer`` and
-``PaymentProof``) and can additionally encode them as ZAP binary messages.
-
-This module is intentionally dependency-free: it maps between the stable JSON
-shape documented by the A2A x402 spec and Switchboard's existing dataclasses
-without importing the A2A SDK, pydantic models, or x402 facilitator libraries.
-That keeps the adapter usable in clients that only need to bridge wire formats.
+The adapter is intentionally small and pure: it converts Switchboard's
+``PaymentOffer`` and ``PaymentProof`` data classes to and from the JSON
+metadata shape used by the A2A x402 extension. It does not sign, verify, or
+settle payments.
 """
 
 from __future__ import annotations
 
-import time
-from collections.abc import Mapping
-from typing import Any
+from typing import Any, Mapping
 
-from switchboard.x402_middleware import PaymentOffer, PaymentProof
+from switchboard.x402_middleware import PaymentOffer, PaymentProof, PaymentScheme
 
-PAYMENT_STATUS_KEY = "x402.payment.status"
-PAYMENT_REQUIRED_KEY = "x402.payment.required"
-PAYMENT_PAYLOAD_KEY = "x402.payment.payload"
-PAYMENT_REQUIRED = "payment-required"
-PAYMENT_SUBMITTED = "payment-submitted"
 
-_CHAIN_TO_NETWORK = {
+A2A_X402_EXTENSION_URI = "https://github.com/google-a2a/a2a-x402/v0.1"
+X402_VERSION = 1
+
+_CHAIN_ID_TO_NETWORK = {
     1: "ethereum",
     8453: "base",
     84532: "base-sepolia",
-    11155111: "sepolia",
 }
-_NETWORK_TO_CHAIN = {network: chain_id for chain_id, network in _CHAIN_TO_NETWORK.items()}
-_NETWORK_TO_CHAIN.update({"mainnet": 1, "eth": 1})
+_NETWORK_TO_CHAIN_ID = {network: chain_id for chain_id, network in _CHAIN_ID_TO_NETWORK.items()}
 
 
-def to_a2a_request(offer: PaymentOffer) -> dict[str, Any]:
-    """Convert a Switchboard ``PaymentOffer`` to standalone A2A x402 JSON.
+class A2AX402AdapterError(ValueError):
+    """Raised when an A2A x402 payload cannot be converted safely."""
 
-    The returned object is a complete ``message/send`` JSON-RPC request body
-    whose message metadata contains ``x402.payment.status`` and
-    ``x402.payment.required``. Callers that already build their own A2A message
-    can reuse ``request["params"]["message"]["metadata"]`` directly.
+
+def to_a2a_request(offer: PaymentOffer, *, mime_type: str = "application/json") -> dict[str, Any]:
+    """Convert a Switchboard payment offer to A2A x402 payment-required metadata.
+
+    The returned object is suitable for the ``x402.payment.required`` metadata
+    field described by the A2A x402 v0.1 specification.
     """
 
-    requirements = _offer_to_payment_requirements(offer)
-    return {
-        "jsonrpc": "2.0",
-        "method": "message/send",
-        "params": {
-            "message": {
-                "role": "agent",
-                "parts": [
-                    {
-                        "kind": "text",
-                        "text": offer.description or "Payment required.",
-                    }
-                ],
-                "metadata": {
-                    PAYMENT_STATUS_KEY: PAYMENT_REQUIRED,
-                    PAYMENT_REQUIRED_KEY: {
-                        "x402Version": 1,
-                        "accepts": [requirements],
-                        "error": "Payment required",
-                    },
-                },
-            }
-        },
+    requirement: dict[str, Any] = {
+        "scheme": offer.scheme.value,
+        "network": network_from_chain_id(offer.chain_id),
+        "asset": offer.currency,
+        "payTo": offer.recipient,
+        "maxAmountRequired": str(offer.amount_wei),
     }
+
+    if offer.endpoint:
+        requirement["resource"] = offer.endpoint
+    if offer.description:
+        requirement["description"] = offer.description
+    if mime_type:
+        requirement["mimeType"] = mime_type
+
+    extra: dict[str, Any] = {}
+    if offer.nonce:
+        extra["nonce"] = offer.nonce
+    if offer.expires_at is not None:
+        extra["expiresAt"] = offer.expires_at
+    if extra:
+        requirement["extra"] = extra
+
+    return {
+        "x402Version": X402_VERSION,
+        "accepts": [requirement],
+    }
+
+
+def from_a2a_request(payload: Mapping[str, Any], *, endpoint: str = "") -> PaymentOffer:
+    """Convert A2A x402 payment-required metadata back to ``PaymentOffer``."""
+
+    required = _metadata_value(payload, "x402.payment.required") or payload
+    accepts = required.get("accepts")
+    if not isinstance(accepts, list) or not accepts:
+        raise A2AX402AdapterError("A2A x402 request must contain a non-empty accepts list")
+
+    requirement = accepts[0]
+    if not isinstance(requirement, Mapping):
+        raise A2AX402AdapterError("A2A x402 payment requirement must be an object")
+
+    extra = requirement.get("extra")
+    if extra is None:
+        extra = {}
+    if not isinstance(extra, Mapping):
+        raise A2AX402AdapterError("A2A x402 payment requirement extra must be an object")
+
+    chain_id = chain_id_from_network(_required_str(requirement, "network"))
+
+    return PaymentOffer(
+        amount_wei=_required_int(requirement, "maxAmountRequired"),
+        currency=_required_str(requirement, "asset"),
+        recipient=_required_str(requirement, "payTo"),
+        chain_id=chain_id,
+        scheme=PaymentScheme(str(requirement.get("scheme", "exact"))),
+        description=str(requirement.get("description", "")),
+        endpoint=endpoint or str(requirement.get("resource", "")),
+        nonce=str(extra.get("nonce", "")),
+        expires_at=_optional_int(extra.get("expiresAt")),
+    )
 
 
 def from_a2a_response(payload: Mapping[str, Any]) -> PaymentProof:
-    """Extract a Switchboard ``PaymentProof`` from A2A x402 response JSON.
+    """Convert A2A x402 payment receipt/submission metadata to ``PaymentProof``.
 
-    ``payload`` may be any of the common standalone-flow shapes:
-
-    - a full JSON-RPC ``message/send`` request body,
-    - an A2A ``message`` object,
-    - a metadata dict containing ``x402.payment.payload``, or
-    - the ``PaymentPayload`` object itself.
-
-    The adapter accepts both camelCase aliases from x402/a2a JSON and the
-    snake_case field names used by Python model dumps.
+    The function accepts both final ``x402.payment.receipts`` entries and direct
+    ``x402.payment.payload``/``payload`` objects, because client and merchant
+    implementations expose different envelope depths.
     """
 
-    payment_payload = _extract_payment_payload(payload)
-    inner = _as_mapping(payment_payload.get("payload"), "payload")
-    authorization = _as_mapping(inner.get("authorization", {}), "payload.authorization")
+    proof_payload = _extract_proof_payload(payload)
 
-    network = _string(payment_payload.get("network"), "network")
-    chain_id = _chain_id_from_network(network)
+    tx_hash = _first_str(proof_payload, "transaction", "txHash", "transactionHash")
+    if not tx_hash:
+        raise A2AX402AdapterError("A2A x402 response is missing transaction/txHash")
 
-    payer = _first_string(
-        inner,
-        authorization,
-        keys=("payer", "from", "fromAddress", "from_address"),
-        field_name="payer/from",
-    )
-    amount = _first_int(
-        inner,
-        authorization,
-        keys=("amount", "value", "maxAmountRequired", "max_amount_required"),
-        field_name="amount/value",
-    )
-    tx_hash = _optional_first_string(
-        inner,
-        payment_payload,
-        keys=("txHash", "tx_hash", "transaction", "hash", "signature"),
-    ) or _synthetic_signature_reference(inner)
-    nonce = _optional_first_string(
-        inner,
-        authorization,
-        keys=("nonce", "paymentNonce", "payment_nonce"),
-    ) or ""
+    network = _first_str(proof_payload, "network")
+    chain_id_value = _first_value(proof_payload, "chainId", "chain_id")
+    if chain_id_value is not None:
+        chain_id = _to_int(chain_id_value, "chainId")
+    elif network:
+        chain_id = chain_id_from_network(network)
+    else:
+        raise A2AX402AdapterError("A2A x402 response is missing network/chainId")
 
-    return PaymentProof(
-        tx_hash=tx_hash,
-        chain_id=chain_id,
-        payer=payer,
-        amount_wei=amount,
-        nonce=nonce,
-        timestamp=float(int(time.time())),
-    )
+    amount_value = _first_value(proof_payload, "amount", "amountWei", "maxAmountRequired")
+    amount_wei = _to_int(amount_value, "amount") if amount_value is not None else 0
+
+    timestamp_value = _first_value(proof_payload, "timestamp")
+    proof_kwargs: dict[str, Any] = {
+        "tx_hash": tx_hash,
+        "chain_id": chain_id,
+        "payer": _first_str(proof_payload, "payer", "from") or "",
+        "amount_wei": amount_wei,
+        "nonce": _first_str(proof_payload, "nonce") or "",
+    }
+    if timestamp_value is not None:
+        proof_kwargs["timestamp"] = float(timestamp_value)
+
+    return PaymentProof(**proof_kwargs)
 
 
-def _offer_to_payment_requirements(offer: PaymentOffer) -> dict[str, Any]:
-    max_timeout = 600
-    if offer.expires_at is not None:
-        max_timeout = max(0, int(offer.expires_at - time.time()))
+def to_a2a_submission(proof: PaymentProof, *, network: str | None = None) -> dict[str, Any]:
+    """Convert a Switchboard proof to A2A x402 payment-submitted metadata."""
 
     return {
-        "scheme": offer.scheme.value,
-        "network": _network_from_chain_id(offer.chain_id),
-        "payTo": offer.recipient,
-        "maxAmountRequired": str(offer.amount_wei),
-        "asset": offer.currency,
-        "resource": offer.endpoint or "/",
-        "description": offer.description,
-        "mimeType": "application/json",
-        "maxTimeoutSeconds": max_timeout,
-        "extra": {
-            "switchboard": {
-                "chainId": offer.chain_id,
-                "currency": offer.currency,
-                "nonce": offer.nonce,
-                "scheme": offer.scheme.value,
-            }
+        "x402.payment.status": "payment-submitted",
+        "x402.payment.payload": {
+            "x402Version": X402_VERSION,
+            "network": network or network_from_chain_id(proof.chain_id),
+            "scheme": "exact",
+            "payload": {
+                "txHash": proof.tx_hash,
+                "chainId": proof.chain_id,
+                "payer": proof.payer,
+                "amount": str(proof.amount_wei),
+                "nonce": proof.nonce,
+                "timestamp": int(proof.timestamp),
+            },
         },
     }
 
 
-def _extract_payment_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
-    current: Any = payload
+def to_a2a_receipt(proof: PaymentProof, *, success: bool = True) -> dict[str, Any]:
+    """Convert a Switchboard proof to an A2A x402 settlement receipt."""
 
-    if "params" in current:
-        current = _as_mapping(current["params"], "params").get("message", current)
-    if "message" in current:
-        current = current["message"]
-    if "metadata" in current:
-        current = _as_mapping(current["metadata"], "metadata")
-    if PAYMENT_PAYLOAD_KEY in current:
-        current = current[PAYMENT_PAYLOAD_KEY]
-
-    current = _as_mapping(current, PAYMENT_PAYLOAD_KEY)
-    if "payload" not in current:
-        raise ValueError("A2A x402 response is missing payment payload data")
-    return current
+    return {
+        "success": success,
+        "transaction": proof.tx_hash if success else "",
+        "network": network_from_chain_id(proof.chain_id),
+        "payer": proof.payer,
+        "amount": str(proof.amount_wei),
+        "nonce": proof.nonce,
+        "timestamp": int(proof.timestamp),
+    }
 
 
-def _network_from_chain_id(chain_id: int) -> str:
-    return _CHAIN_TO_NETWORK.get(chain_id, f"eip155:{chain_id}")
+def network_from_chain_id(chain_id: int) -> str:
+    """Return the A2A x402 network name for a numeric EVM chain id."""
+
+    return _CHAIN_ID_TO_NETWORK.get(chain_id, f"eip155:{chain_id}")
 
 
-def _chain_id_from_network(network: str) -> int:
-    if network in _NETWORK_TO_CHAIN:
-        return _NETWORK_TO_CHAIN[network]
+def chain_id_from_network(network: str) -> int:
+    """Return a numeric chain id for an A2A x402 network name."""
+
+    if network in _NETWORK_TO_CHAIN_ID:
+        return _NETWORK_TO_CHAIN_ID[network]
     if network.startswith("eip155:"):
-        return int(network.split(":", 1)[1])
-    raise ValueError(f"Unsupported x402 network: {network}")
+        return _to_int(network.split(":", 1)[1], "network")
+    raise A2AX402AdapterError(f"Unknown A2A x402 network: {network}")
 
 
-def _as_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
-    if isinstance(value, Mapping):
-        return value
-    raise ValueError(f"{field_name} must be an object")
+def _extract_proof_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    metadata = payload.get("metadata")
+    if isinstance(metadata, Mapping):
+        nested = _extract_from_metadata(metadata)
+        if nested is not None:
+            return nested
+
+    nested = _extract_from_metadata(payload)
+    if nested is not None:
+        return nested
+
+    return payload
 
 
-def _string(value: Any, field_name: str) -> str:
-    if isinstance(value, str) and value:
-        return value
-    raise ValueError(f"{field_name} must be a non-empty string")
+def _extract_from_metadata(payload: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    receipts = payload.get("x402.payment.receipts")
+    if isinstance(receipts, list) and receipts:
+        last_receipt = receipts[-1]
+        if isinstance(last_receipt, Mapping):
+            return last_receipt
 
+    for key in ("x402.payment.payload", "paymentPayload", "payment", "proof", "payload"):
+        candidate = payload.get(key)
+        if isinstance(candidate, Mapping):
+            if key == "payload":
+                merged = dict(payload)
+                merged.update(candidate)
+                return merged
+            nested_payload = candidate.get("payload")
+            if isinstance(nested_payload, Mapping):
+                merged = dict(candidate)
+                merged.update(nested_payload)
+                return merged
+            return candidate
 
-def _first_string(
-    primary: Mapping[str, Any],
-    secondary: Mapping[str, Any],
-    *,
-    keys: tuple[str, ...],
-    field_name: str,
-) -> str:
-    value = _optional_first_string(primary, secondary, keys=keys)
-    if value is None:
-        raise ValueError(f"A2A x402 payload is missing {field_name}")
-    return value
-
-
-def _optional_first_string(
-    primary: Mapping[str, Any],
-    secondary: Mapping[str, Any],
-    *,
-    keys: tuple[str, ...],
-) -> str | None:
-    for mapping in (primary, secondary):
-        for key in keys:
-            value = mapping.get(key)
-            if isinstance(value, str) and value:
-                return value
     return None
 
 
-def _first_int(
-    primary: Mapping[str, Any],
-    secondary: Mapping[str, Any],
-    *,
-    keys: tuple[str, ...],
-    field_name: str,
-) -> int:
-    for mapping in (primary, secondary):
-        for key in keys:
-            if key not in mapping:
-                continue
-            value = mapping[key]
-            if isinstance(value, int):
-                return value
-            if isinstance(value, str) and value.isdigit():
-                return int(value)
-    raise ValueError(f"A2A x402 payload is missing numeric {field_name}")
+def _metadata_value(payload: Mapping[str, Any], key: str) -> Any:
+    if key in payload:
+        return payload[key]
+    metadata = payload.get("metadata")
+    if isinstance(metadata, Mapping):
+        return metadata.get(key)
+    return None
 
 
-def _synthetic_signature_reference(inner: Mapping[str, Any]) -> str:
-    """Return a stable proof reference when a facilitator tx is not present yet."""
+def _required_str(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if value is None or value == "":
+        raise A2AX402AdapterError(f"A2A x402 payload is missing {key}")
+    return str(value)
 
-    signature = _optional_first_string(inner, {}, keys=("signature",))
-    if not signature:
-        raise ValueError("A2A x402 payload is missing txHash/transaction/signature")
-    return signature
+
+def _required_int(payload: Mapping[str, Any], key: str) -> int:
+    return _to_int(payload.get(key), key)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    return _to_int(value, "optional integer")
+
+
+def _first_value(payload: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in payload and payload[key] is not None:
+            return payload[key]
+    return None
+
+
+def _first_str(payload: Mapping[str, Any], *keys: str) -> str:
+    value = _first_value(payload, *keys)
+    return "" if value is None else str(value)
+
+
+def _to_int(value: Any, field: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise A2AX402AdapterError(f"A2A x402 field {field} must be an integer") from exc

--- a/tests/test_a2a_x402_adapter.py
+++ b/tests/test_a2a_x402_adapter.py
@@ -1,172 +1,164 @@
-from __future__ import annotations
+"""Round-trip tests for the A2A x402 adapter."""
 
 import pytest
 
 from switchboard.adapters.a2a_x402 import (
-    PAYMENT_PAYLOAD_KEY,
-    PAYMENT_REQUIRED_KEY,
-    PAYMENT_STATUS_KEY,
+    A2AX402AdapterError,
+    chain_id_from_network,
+    from_a2a_request,
     from_a2a_response,
+    network_from_chain_id,
+    to_a2a_receipt,
     to_a2a_request,
+    to_a2a_submission,
 )
-from switchboard.x402_middleware import PaymentOffer, PaymentProof, PaymentScheme
-
-RECIPIENT = "0x1111111111111111111111111111111111111111"
-PAYER = "0x2222222222222222222222222222222222222222"
-SIGNATURE = "0x" + "ab" * 32
+from switchboard.x402_middleware import PaymentOffer, PaymentProof
 
 
-def sample_offer() -> PaymentOffer:
-    return PaymentOffer(
-        amount_wei=1_000_000,
-        currency="USDC",
-        recipient=RECIPIENT,
+def test_offer_to_a2a_request_uses_spec_shape():
+    offer = PaymentOffer(
+        amount_wei=48_240_000,
+        currency="0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
+        recipient="0xServerWalletAddressHere",
         chain_id=8453,
-        scheme=PaymentScheme.EXACT,
-        description="Generate one image",
-        endpoint="/v1/images",
-        nonce="offer-nonce-1",
-        expires_at=2_000_000_000,
+        description="Generate an image",
+        endpoint="https://api.example.com/generate-image",
+        nonce="nonce-1",
+        expires_at=1_800_000_000,
     )
 
+    payload = to_a2a_request(offer)
 
-def sample_payment_payload() -> dict:
-    return {
-        "x402Version": 1,
-        "scheme": "exact",
-        "network": "base",
-        "payload": {
-            "signature": SIGNATURE,
-            "authorization": {
-                "from": PAYER,
-                "to": RECIPIENT,
-                "value": "1000000",
-                "validAfter": "0",
-                "validBefore": "2000000000",
-                "nonce": "proof-nonce-1",
-            },
-        },
-    }
-
-
-def test_to_a2a_request_places_payment_required_metadata():
-    request = to_a2a_request(sample_offer())
-
-    assert request["jsonrpc"] == "2.0"
-    assert request["method"] == "message/send"
-    metadata = request["params"]["message"]["metadata"]
-    assert metadata[PAYMENT_STATUS_KEY] == "payment-required"
-
-    required = metadata[PAYMENT_REQUIRED_KEY]
-    assert required["x402Version"] == 1
-    assert required["error"] == "Payment required"
-    assert len(required["accepts"]) == 1
-
-
-def test_to_a2a_request_maps_offer_to_payment_requirements():
-    request = to_a2a_request(sample_offer())
-    requirement = request["params"]["message"]["metadata"][PAYMENT_REQUIRED_KEY]["accepts"][0]
-
+    assert payload["x402Version"] == 1
+    requirement = payload["accepts"][0]
     assert requirement["scheme"] == "exact"
     assert requirement["network"] == "base"
-    assert requirement["payTo"] == RECIPIENT
-    assert requirement["maxAmountRequired"] == "1000000"
-    assert requirement["asset"] == "USDC"
-    assert requirement["resource"] == "/v1/images"
-    assert requirement["description"] == "Generate one image"
-    assert requirement["mimeType"] == "application/json"
-    assert requirement["extra"]["switchboard"]["chainId"] == 8453
-    assert requirement["extra"]["switchboard"]["nonce"] == "offer-nonce-1"
+    assert requirement["resource"] == "https://api.example.com/generate-image"
+    assert requirement["asset"] == "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913"
+    assert requirement["payTo"] == "0xServerWalletAddressHere"
+    assert requirement["maxAmountRequired"] == "48240000"
+    assert requirement["extra"]["nonce"] == "nonce-1"
+    assert requirement["extra"]["expiresAt"] == 1_800_000_000
 
 
-def test_to_a2a_request_uses_eip155_network_for_unknown_chain():
-    offer = sample_offer()
-    offer.chain_id = 999999
+def test_a2a_request_roundtrips_to_payment_offer():
+    original = PaymentOffer(
+        amount_wei=1000,
+        currency="USDC",
+        recipient="0xabc",
+        chain_id=84532,
+        endpoint="/paid/task",
+        nonce="n1",
+    )
 
-    requirement = to_a2a_request(offer)["params"]["message"]["metadata"][PAYMENT_REQUIRED_KEY][
-        "accepts"
-    ][0]
+    parsed = from_a2a_request(to_a2a_request(original))
 
-    assert requirement["network"] == "eip155:999999"
+    assert parsed.amount_wei == original.amount_wei
+    assert parsed.currency == original.currency
+    assert parsed.recipient == original.recipient
+    assert parsed.chain_id == original.chain_id
+    assert parsed.endpoint == original.endpoint
+    assert parsed.nonce == original.nonce
 
 
-def test_from_a2a_response_accepts_full_jsonrpc_message_send_body():
-    response = {
-        "jsonrpc": "2.0",
-        "method": "message/send",
-        "params": {
-            "message": {
-                "taskId": "task-123",
-                "role": "user",
-                "parts": [{"kind": "text", "text": "Here is the payment authorization."}],
-                "metadata": {
-                    PAYMENT_STATUS_KEY: "payment-submitted",
-                    PAYMENT_PAYLOAD_KEY: sample_payment_payload(),
-                },
-            }
-        },
+def test_a2a_receipt_converts_to_payment_proof():
+    payload = {
+        "metadata": {
+            "x402.payment.status": "payment-completed",
+            "x402.payment.receipts": [
+                {
+                    "success": True,
+                    "transaction": "0xabc123",
+                    "network": "base",
+                    "payer": "0xpayer",
+                    "amount": "48240000",
+                    "nonce": "nonce-1",
+                    "timestamp": 1_700_000_000,
+                }
+            ],
+        }
     }
-
-    proof = from_a2a_response(response)
-
-    assert isinstance(proof, PaymentProof)
-    assert proof.tx_hash == SIGNATURE
-    assert proof.chain_id == 8453
-    assert proof.payer == PAYER
-    assert proof.amount_wei == 1_000_000
-    assert proof.nonce == "proof-nonce-1"
-
-
-def test_from_a2a_response_accepts_metadata_dict_directly():
-    proof = from_a2a_response({PAYMENT_PAYLOAD_KEY: sample_payment_payload()})
-
-    assert proof.tx_hash == SIGNATURE
-    assert proof.chain_id == 8453
-    assert proof.payer == PAYER
-
-
-def test_from_a2a_response_prefers_facilitator_transaction_reference_when_present():
-    payload = sample_payment_payload()
-    payload["payload"]["transaction"] = "0xsettled"
 
     proof = from_a2a_response(payload)
 
-    assert proof.tx_hash == "0xsettled"
+    assert proof.tx_hash == "0xabc123"
+    assert proof.chain_id == 8453
+    assert proof.payer == "0xpayer"
+    assert proof.amount_wei == 48_240_000
+    assert proof.nonce == "nonce-1"
+    assert proof.timestamp == 1_700_000_000
 
 
-def test_from_a2a_response_supports_eip155_networks_and_top_level_amounts():
+def test_a2a_payment_payload_aliases_convert_to_payment_proof():
+    payload = {
+        "x402.payment.payload": {
+            "x402Version": 1,
+            "network": "base-sepolia",
+            "scheme": "exact",
+            "payload": {
+                "txHash": "0xdef456",
+                "payer": "0xpayer",
+                "amount": "2500",
+            },
+        }
+    }
+
+    proof = from_a2a_response(payload)
+
+    assert proof.tx_hash == "0xdef456"
+    assert proof.chain_id == 84532
+    assert proof.amount_wei == 2500
+
+
+def test_direct_payment_payload_preserves_outer_network():
     payload = {
         "x402Version": 1,
+        "network": "base",
         "scheme": "exact",
-        "network": "eip155:11155111",
         "payload": {
-            "txHash": "0xabc123",
-            "payer": PAYER,
-            "amount": 42,
-            "nonce": "n1",
+            "txHash": "0xfeed",
+            "payer": "0xpayer",
+            "amount": "12",
         },
     }
 
     proof = from_a2a_response(payload)
 
-    assert proof.chain_id == 11155111
-    assert proof.tx_hash == "0xabc123"
-    assert proof.amount_wei == 42
-    assert proof.nonce == "n1"
+    assert proof.tx_hash == "0xfeed"
+    assert proof.chain_id == 8453
 
 
-@pytest.mark.parametrize(
-    ("payload", "message"),
-    [
-        ({"network": "base"}, "missing payment payload"),
-        ({"network": "unknown", "payload": {"signature": SIGNATURE}}, "Unsupported x402 network"),
-        ({"network": "base", "payload": {"signature": SIGNATURE}}, "missing payer/from"),
-        (
-            {"network": "base", "payload": {"signature": SIGNATURE, "payer": PAYER}},
-            "missing numeric amount/value",
-        ),
-    ],
-)
-def test_from_a2a_response_rejects_malformed_payloads(payload: dict, message: str):
-    with pytest.raises(ValueError, match=message):
-        from_a2a_response(payload)
+def test_switchboard_proof_exports_submission_and_receipt():
+    proof = PaymentProof(
+        tx_hash="0xabc",
+        chain_id=8453,
+        payer="0xpayer",
+        amount_wei=999,
+        nonce="n1",
+        timestamp=1_700_000_000,
+    )
+
+    submission = to_a2a_submission(proof)
+    receipt = to_a2a_receipt(proof)
+
+    assert submission["x402.payment.status"] == "payment-submitted"
+    assert submission["x402.payment.payload"]["network"] == "base"
+    assert submission["x402.payment.payload"]["payload"]["txHash"] == "0xabc"
+    assert receipt["success"] is True
+    assert receipt["transaction"] == "0xabc"
+    assert receipt["network"] == "base"
+
+
+def test_unknown_network_is_rejected():
+    with pytest.raises(A2AX402AdapterError, match="Unknown"):
+        chain_id_from_network("unknown-chain")
+
+
+def test_eip155_network_roundtrip():
+    assert network_from_chain_id(10) == "eip155:10"
+    assert chain_id_from_network("eip155:10") == 10
+
+
+def test_response_without_transaction_is_rejected():
+    with pytest.raises(A2AX402AdapterError, match="transaction"):
+        from_a2a_response({"network": "base", "amount": "1"})


### PR DESCRIPTION
## Summary

- add `switchboard.adapters.a2a_x402` for translating Switchboard payment envelopes to A2A x402 v0.1 metadata
- support `PaymentOffer -> x402.payment.required`, A2A receipt/payload -> `PaymentProof`, and `PaymentProof -> payment-submitted/receipt` helpers
- document merchant/client usage in `docs/adapters/a2a-x402.md`
- add round-trip tests for payment-required metadata, receipts, direct payment payloads, and network mapping

## Verification

- `python -m pytest tests/test_a2a_x402_adapter.py` -> 9 passed
- `python -m pytest tests/test_a2a_x402_adapter.py tests/test_gas_budget.py tests/test_gas_tracker.py tests/test_payment_protocol.py tests/test_x402_middleware.py tests/test_zap_transport.py` -> 59 passed, 1 skipped

Full suite note: `python -m pytest` still has existing `tests/test_nonce_manager.py` failures unrelated to this adapter. This PR only adds files under `switchboard/adapters`, `docs/adapters`, and adapter tests.

Refs #29
