### PR TITLE
RFC + agent-payments lab: PQ-signed envelopes, 15-scene interactive demo

### DIFF
--- a/docs/post-quantum.md
+++ b/docs/post-quantum.md
@@ -1,0 +1,262 @@
+# Post-Quantum Signed Agent-to-Agent Payments
+
+**Status:** Design draft v0.1
+**Owner:** @Pattermesh (drafting) / @abhicris (review)
+**Tracks meta-issue:** TBD
+
+---
+
+## 1. Why now
+
+Switchboard's A2A payment protocol v1.0 ships unsigned at the application
+layer. Authenticity rides on two assumptions:
+
+1. **HTTPS / TLS** for the HTTP path (`X-Payment-Required`, `X-Payment-Proof`
+   in `x402_middleware.py`).
+2. **secp256k1 ECDSA on the Ethereum tx** for on-chain settlement — the
+   "proof" a receiver checks is `tx_hash` resolution against the chain.
+
+Neither holds in a post-quantum future. Shor breaks secp256k1 on day one;
+TLS without PQ-hybrid suites is recoverable from "harvest-now-decrypt-later"
+captures. Switchboard is the substrate; if we want it to outlive the
+classical-crypto era we add an **application-layer PQ signature on the
+payment envelopes themselves**, independent of the rail.
+
+This is also the cleanest place to validate Lux's PQ stack (`threshold`,
+`fhe`, `mpc`, `proofs`) against a real consumer.
+
+## 2. Threat model
+
+| Adversary capability        | Today's defense          | After this work                                    |
+| --------------------------- | ------------------------ | -------------------------------------------------- |
+| Passive TLS capture (now)   | TLS 1.3                  | PQ sig on envelope — capture reveals nothing usable |
+| TLS break (future quantum)  | none                     | PQ sig on envelope still verifies                  |
+| Fake `PaymentOffer` injection in-band | tx-hash check only useful *after* paying | PQ sig on offer — verify before paying |
+| ECDSA break (future quantum) | none on-chain            | hybrid mode pairs PQ with ECDSA; off-chain proof still verifies; full on-chain PQ tracked separately under Lux escrow variant |
+
+Out of scope for this design: defending the EVM tx signature itself.
+That requires a PQ-aware chain (Lux). We cover the off-chain envelope
+and provide hooks for a Lux-native escrow.
+
+## 3. Wire format
+
+### 3.1 Algorithm registry
+
+Algorithm tag is a single `uint8` on the ZAP wire and a string on JSON.
+
+| tag  | name              | sig size  | pk size  | source                |
+| ---- | ----------------- | --------- | -------- | --------------------- |
+| 0x00 | `none`            | 0         | 0        | sentinel, unsigned    |
+| 0x01 | `ecdsa-secp256k1` | 65 (r,s,v)| 33 (cmp) | classical, existing   |
+| 0x10 | `ml-dsa-44`       | 2,420     | 1,312    | FIPS 204              |
+| 0x11 | `ml-dsa-65`       | 3,309     | 1,952    | FIPS 204              |
+| 0x12 | `ml-dsa-87`       | 4,627     | 2,592    | FIPS 204              |
+| 0x20 | `slh-dsa-128s`    | 7,856     | 32       | FIPS 205              |
+| 0x21 | `slh-dsa-128f`    | 17,088    | 32       | FIPS 205              |
+| 0x80 | `hybrid-ecdsa-ml-dsa-65` | 65+3,309 | 33+1,952 | concat, both verify |
+
+Default for v1: `ml-dsa-65`. Hybrid mode `0x80` is recommended during
+migration so a verifier rejecting one of the two halves rejects the
+message.
+
+### 3.2 Signing transcript
+
+The bytes signed are a domain-separated hash of the canonical payload:
+
+```
+transcript = "switchboard/pq/v1\0" || <payload-type-tag> || <canonical-bytes>
+digest     = SHAKE-256(transcript, 64)
+signature  = Sign(sk, digest)
+```
+
+`<payload-type-tag>` is `0x01` for `PaymentOffer`, `0x02` for
+`PaymentProof`, `0x03` for `PaymentRequest`. Domain separation
+guarantees a signature on an offer can't be replayed as a proof.
+
+`<canonical-bytes>` for JSON payloads = the existing `content_hash`
+input (sorted keys, tight separators, `created_at` and `status`
+excluded, plus the new `signature` and `signature_alg` fields also
+excluded since they're the things being computed).
+
+For ZAP wire payloads, `<canonical-bytes>` = the bytes of the
+`StructBuilder.build()` output with `signature` and `signature_alg`
+fields zeroed. This keeps offset arithmetic stable.
+
+### 3.3 Schema additions
+
+`PaymentOffer` and `PaymentProof` gain two optional fields:
+
+```python
+@dataclass
+class PaymentOffer:
+    # … existing fields …
+    signature_alg: str = "none"     # registry name, JSON
+    signature: bytes = b""           # raw bytes; base64 in JSON, raw on wire
+```
+
+ZAP `StructBuilder` additions, appended after existing fields so old
+readers ignore them:
+
+```python
+.uint8("signature_alg")
+.bytes("signature")          # variable-length, see _AMOUNT_BYTES pattern
+```
+
+`PaymentRequest` (in `src/payment_protocol.py`) gains the same two
+fields. Spec §2 table extended.
+
+## 4. Key management
+
+New module `switchboard/pq_keys.py`:
+
+```python
+class PQKeyPair:
+    alg: str                  # registry name
+    sk: bytes                 # secret key, owner-only
+    pk: bytes                 # public key
+    key_id: str               # sha256(pk)[:16] hex, the agent's PQ identity
+
+    @classmethod
+    def generate(cls, alg: str = "ml-dsa-65") -> "PQKeyPair": ...
+    @classmethod
+    def load(cls, path: str, passphrase: bytes | None = None) -> "PQKeyPair": ...
+    def save(self, path: str, passphrase: bytes | None = None) -> None: ...
+    def sign(self, transcript: bytes) -> bytes: ...
+
+def verify(alg: str, pk: bytes, transcript: bytes, sig: bytes) -> bool: ...
+```
+
+Storage on disk: PEM-like file with KDF-wrapped secret key
+(scrypt, then chacha20-poly1305). No on-chain key publication in v1;
+agents exchange `pk` out-of-band or via a future `.well-known/agent-payment.json`.
+
+## 5. Verification flow
+
+```
+                  PaymentOffer received
+                            │
+                            ▼
+            ┌─────────────────────────┐
+            │ offer.signature_alg     │
+            └───────────┬─────────────┘
+                        │
+       ┌────────────────┼────────────────┐
+       │                │                │
+       ▼                ▼                ▼
+    "none"        "ecdsa-…"        "ml-dsa-…" / "hybrid-…"
+    accept iff    classical        PQ verify (+ ECDSA half
+    not in       ECDSA verify       if hybrid). Reject if any
+    strict mode                     half fails.
+```
+
+`X402Middleware` adds a `require_signed: bool = False` (default off
+during migration) and `accepted_algs: set[str]`. When `True`, an
+unsigned offer is treated as a parse error.
+
+The provider side (server middleware) signs its own outgoing offers
+with `pq_signer` if configured.
+
+## 6. On-chain story
+
+Two paths, separately tracked.
+
+**Path A — Off-chain envelope only (in scope).** The PQ sig
+authenticates the offer/proof to the *counterparty*. On-chain
+settlement still goes through the existing `AgentEscrow.sol` with
+ECDSA tx signatures. Trust model improvement: an offer's authenticity
+is verifiable before the payer commits funds.
+
+**Path B — Lux-native PQ escrow (out of scope; tracked).**
+`contracts/AgentEscrowPQ.sol` (or a Lux-side equivalent) accepts a
+`bytes signature, uint8 alg` pair on `createPayment` and verifies it
+via a Lux precompile. Requires `luxfi/threshold` or a precompile in
+the EVM extensions on Lux. Defer to a follow-up; capture the
+interface here for forward-compat.
+
+## 7. Migration plan
+
+1. **v1.1 — non-breaking.** Add fields, default `signature_alg="none"`,
+   `require_signed=False`. Existing payloads unchanged.
+2. **v1.2 — hybrid recommended.** Docs + samples promote
+   `hybrid-ecdsa-ml-dsa-65`. Web explorer shows sig presence.
+3. **v2.0 — PQ default.** `require_signed=True` becomes the
+   middleware default. Unsigned offers logged + rejected.
+4. **v2.x — Lux escrow.** On-chain PQ verification ships
+   independently.
+
+## 8. Dependencies
+
+- `liboqs-python` (Open Quantum Safe) — covers ML-DSA, SLH-DSA.
+  Optional dep, gated like `zap_py`. Native build; pin via wheel
+  where available.
+- Existing: `eth-account` for the ECDSA half of hybrid.
+- New optional extra: `pip install 'switchboard-agents[pq]'`.
+
+Pure-Python fallback (e.g. `dilithium-py`) for environments
+without native deps, with a loud "slow path" warning. Useful for
+test rigs only.
+
+## 9. Test vectors
+
+Add three fixtures to `tests/protocol_vectors/payment_request.v1.json`
+(or a new `payment_request.v1.pq.json` keyed off the same payloads):
+
+| Fixture                   | Alg                       | Exercises                                     |
+| ------------------------- | ------------------------- | --------------------------------------------- |
+| `fixture-04-mldsa65-minimal` | `ml-dsa-65`            | required-only payload + ML-DSA-65 signature   |
+| `fixture-05-slhdsa128s`   | `slh-dsa-128s`            | hash-based fallback, conservative assumption  |
+| `fixture-06-hybrid`       | `hybrid-ecdsa-ml-dsa-65`  | both halves must verify; deterministic ECDSA  |
+
+Each fixture pins:
+- input payload
+- public key (hex)
+- signing transcript bytes (post domain-separation)
+- signature bytes (hex)
+- `expected_verify: true`
+
+A negative twin per fixture flips one transcript byte and asserts
+`verify == false`. Cross-impl interop fixtures live next to
+`luxfi/zap` Go test files.
+
+## 10. Breakdown — issues to file
+
+The first six are ready to ship; the rest depend on these landing.
+
+| # | Title | DoD | Depends on |
+|---|---|---|---|
+| PQ-0 | **Meta: post-quantum signed A2A payments** | parent tracker; checklist below ticks | — |
+| PQ-1 | Spec §11: PQ signatures — wire format + transcript + algorithm registry | `docs/post-quantum.md` merged; `docs/agent-payment-protocol.md` §11 added | — |
+| PQ-2 | `switchboard/pq.py`: thin `liboqs` wrapper + `[pq]` extra | `sign()` / `verify()` for ML-DSA-44/65/87, SLH-DSA-128s/f; CI wheel install | PQ-1 |
+| PQ-3 | `switchboard/pq_keys.py`: `PQKeyPair.generate/load/save/sign`, key-id derivation | passphrase-protected file format; round-trip test | PQ-2 |
+| PQ-4 | Extend `PaymentOffer` / `PaymentProof` dataclasses with `signature_alg`, `signature` | non-breaking default `"none"`; `sign(keypair)` / `verify(pk)` helpers | PQ-3 |
+| PQ-5 | Extend ZAP wire schema with `signature_alg` (`uint8`) + `signature` (`bytes`) | offset constants pinned; back-compat for old readers via append-only | PQ-4 |
+| PQ-6 | Hybrid mode `0x80 hybrid-ecdsa-ml-dsa-65`: concat + both-must-verify | dedicated test, partial-fail cases | PQ-4 |
+| PQ-7 | `X402Middleware`: `require_signed` + `accepted_algs`; reject when policy fails | docs + 4 test cases (signed-ok, signed-wrong-alg, unsigned-strict, hybrid-half-fail) | PQ-4 |
+| PQ-8 | A2A x402 adapter: `extra.signature` + `extra.signatureAlg` (base64) | round-trip tests vs. fixture-04..06 | PQ-4 |
+| PQ-9 | `PaymentRequest.content_hash` v2: domain-separated SHAKE-256 transcript | versioned; v1 hashes still computable; spec §2.2 updated | PQ-1 |
+| PQ-10 | Test vectors fixture-04, fixture-05, fixture-06 + negative twins | `pytest tests/test_protocol_vectors.py` green with PQ deps | PQ-2 |
+| PQ-11 | Conformance: cross-impl interop fixtures with `luxfi/zap` Go side | Go test reads the same JSON file and asserts | PQ-5, PQ-10 |
+| PQ-12 | Web explorer: render `signature_alg`, sig present/absent badge, hybrid status | screenshot in PR | PQ-4 |
+| PQ-13 | **Deferred** — Lux-native PQ escrow contract (`AgentEscrowPQ.sol`) interface sketch | spec stub only; no implementation here | PQ-1 |
+
+## 11. Open questions
+
+- **Algorithm default**: `ml-dsa-65` is the safe NIST-1+ pick; do we
+  want `ml-dsa-87` for higher security margin at +40% sig size?
+- **Hybrid concat order**: ECDSA-then-PQ vs PQ-then-ECDSA. Pin one;
+  any choice is fine as long as it's pinned.
+- **Key rotation cadence**: tied to agent identity. Need an
+  `agent-identity.md` doc separately (cross-cuts with `.well-known`
+  A2A discovery from spec §10).
+- **Storage**: where does `key_id` get published so receivers know
+  which `pk` to use? Out of scope here; rolls into A2A discovery.
+- **Pure-Python fallback**: worth maintaining `dilithium-py` path or
+  is `liboqs-python` enough? Native dep is the only real cost.
+
+## 12. Non-goals
+
+- Replacing ECDSA on the EVM tx itself.
+- Encrypting payment metadata (separate problem: confidentiality,
+  not authenticity; would use PQ-KEM, not PQ-sig).
+- TLS hardening — handled at the transport layer.
+- Threshold / multi-party PQ signatures — interesting but not v1.

--- a/tests/test_web_lab.py
+++ b/tests/test_web_lab.py
@@ -247,3 +247,39 @@ def test_sara_added_as_human(lab_script: str) -> None:
     """Split-bill scene now uses Sara instead of an AI agent."""
     assert 'name: "Sara"' in lab_script
     assert 'kind: "human"' in lab_script   # at least one explicit human kind
+
+
+# ─── scene-controls + live tooltip + why-card ──────────────────────────────
+
+def test_scene_controls_mechanism(lab_script: str) -> None:
+    """Scenes can declare controls; renderer mounts them in #ctlPanel."""
+    assert "renderControls" in lab_script
+    assert "scene.ctl" in lab_script
+    # auction scene declares the new controls
+    assert 'id: "scenario"' in lab_script
+    assert 'id: "bid_eli"' in lab_script
+    assert 'id: "bid_gus"' in lab_script
+    assert 'id: "bid_hana"' in lab_script
+
+
+def test_auction_has_scenario_presets(lab_script: str) -> None:
+    """Three documented scenarios available as preset buttons."""
+    for preset in ('"cheapestWins"', '"overBudget"', '"tie"'):
+        assert preset in lab_script, f"auction preset {preset} missing"
+
+
+def test_tooltip_live_refresh(lab_script: str) -> None:
+    """rAF loop should refresh tooltip while hover is active."""
+    assert "lastClient" in lab_script
+    # The live-refresh hook is inside step(); ensure renderTooltip is called
+    # from inside the loop body, not just from the mousemove handler.
+    step_block = lab_script.split("function step()")[1].split("function renderInfo()")[0]
+    assert "renderTooltip" in step_block, "renderTooltip not called from step() loop"
+
+
+def test_why_card_supported(lab_script: str) -> None:
+    """Scenes can declare a why-card; renderer mounts it under the desc."""
+    assert "renderWhyCard" in lab_script
+    assert "why-card" in lab_script
+    # Escrow scene + auction scene both publish a why
+    assert 'why: "' in lab_script or 'why: `' in lab_script

--- a/tests/test_web_lab.py
+++ b/tests/test_web_lab.py
@@ -101,7 +101,7 @@ def test_scramble_logic_present(lab_script: str) -> None:
 
 EXPECTED_SCENES = [
     "x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle", "pq", "stack",
-    "taxi", "cafe", "delivery", "split",
+    "taxi", "cafe", "delivery", "split", "ethEscrow", "subscribe",
 ]
 
 
@@ -192,3 +192,58 @@ def test_hover_ripple_and_scale(lab_script: str) -> None:
     # ripple state + hover ease are both required by the new hover treatment
     assert "_ripples" in lab_script
     assert "_hoverEase" in lab_script
+
+
+# ─── kinds, shapes, informatics ────────────────────────────────────────────
+
+def test_three_kinds_present(lab_script: str) -> None:
+    """human / bot / contract — every agent should be tagged with one."""
+    for kind in ('"human"', '"bot"', '"contract"'):
+        assert f"kind: {kind}" in lab_script, f"no agents declared as {kind}"
+
+
+def test_shape_dispatch_present(lab_script: str) -> None:
+    """drawAgent should dispatch on the three new shape branches."""
+    for branch in ("squircle", "octagon", "hex"):
+        assert branch in lab_script, f"shape `{branch}` not referenced"
+    assert "drawSquircleBody" in lab_script
+    assert "drawOctagonBody"  in lab_script
+    assert "drawHexBody"      in lab_script
+
+
+def test_tooltip_includes_informatics(lab_script: str) -> None:
+    """Tooltip should surface protocols, sig alg, kind, last seen."""
+    must_contain = ["protocols", "sigAlg", "lastSeen",
+                    "ttproto", "ttdesc"]
+    for s in must_contain:
+        assert s in lab_script, f"tooltip missing informatics field: {s}"
+
+
+def test_scene_groups_present(lab_script: str) -> None:
+    """Pill bar should be grouped: primitives / use cases / meta."""
+    assert "SCENE_GROUPS" in lab_script
+    for label in ('"primitives"', '"use cases"', '"meta"'):
+        assert label in lab_script, f"scene group {label} missing"
+
+
+def test_add_scene_cta_present(lab_script: str, lab_html: str) -> None:
+    """`+ Add your scene` CTA should link to SCENES.md."""
+    assert "add-scene" in lab_script or "add-scene" in lab_html
+    assert "SCENES.md" in lab_script
+
+
+def test_scenes_md_file_exists() -> None:
+    md = WEB / "SCENES.md"
+    assert md.is_file(), "web/SCENES.md missing — scene-template doc is required"
+    body = md.read_text()
+    # contract checks — these are load-bearing for contributors
+    for hook in ("SCENES.myScene", "enter()", "tick(t)", "EXPECTED_SCENES"):
+        assert hook in body, f"SCENES.md missing required example: {hook}"
+
+
+# ─── cast refinement ───────────────────────────────────────────────────────
+
+def test_sara_added_as_human(lab_script: str) -> None:
+    """Split-bill scene now uses Sara instead of an AI agent."""
+    assert 'name: "Sara"' in lab_script
+    assert 'kind: "human"' in lab_script   # at least one explicit human kind

--- a/tests/test_web_lab.py
+++ b/tests/test_web_lab.py
@@ -101,6 +101,7 @@ def test_scramble_logic_present(lab_script: str) -> None:
 
 EXPECTED_SCENES = [
     "x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle", "pq", "stack",
+    "taxi", "cafe", "delivery", "split",
 ]
 
 

--- a/tests/test_web_lab.py
+++ b/tests/test_web_lab.py
@@ -1,0 +1,193 @@
+"""Smoke tests for the agent-payments lab (``web/agents-demo.html``).
+
+The lab is intentionally a no-build single-file frontend, so the test
+surface here is correspondingly small but load-bearing:
+
+- the file parses as HTML and contains the structural anchors we depend on
+- every scene wired into ``SCENE_ORDER`` has a matching ``SCENES.<id>``
+  definition with a name + caption
+- the named cast (Patty, Abhi, Tridib) is wired through the canonical
+  agent registry
+- the home page links to the lab and the lab links back
+- the embedded JavaScript has no syntax errors (run via ``node --check``)
+
+Skip the node check if a ``node`` binary isn't on PATH.
+"""
+
+from __future__ import annotations
+
+import html.parser
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+WEB = HERE.parent / "web"
+LAB = WEB / "agents-demo.html"
+HOME = WEB / "index.html"
+
+
+@pytest.fixture(scope="module")
+def lab_html() -> str:
+    return LAB.read_text()
+
+
+@pytest.fixture(scope="module")
+def home_html() -> str:
+    return HOME.read_text()
+
+
+@pytest.fixture(scope="module")
+def lab_script(lab_html: str) -> str:
+    m = re.search(r"<script>(.*?)</script>", lab_html, re.DOTALL)
+    assert m, "expected one <script> block in lab HTML"
+    return m.group(1)
+
+
+# ─── shape ────────────────────────────────────────────────────────────────
+
+def test_files_exist() -> None:
+    assert LAB.is_file(), f"missing {LAB}"
+    assert HOME.is_file(), f"missing {HOME}"
+
+
+def test_html_parses(lab_html: str) -> None:
+    class P(html.parser.HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.errors: list[str] = []
+
+        def error(self, message: str) -> None:    # pragma: no cover
+            self.errors.append(message)
+
+    p = P()
+    p.feed(lab_html)
+    assert not p.errors, p.errors
+
+
+def test_structural_anchors(lab_html: str) -> None:
+    must_contain = [
+        '<canvas id="canvas">',
+        '<div class="scene-bar" id="sceneBar">',
+        '<div class="tt" id="tooltip">',
+        'id="sbTitle"',
+        'class="sb-char"',
+    ]
+    for s in must_contain:
+        assert s in lab_html, f"missing structural anchor: {s}"
+
+
+# ─── split-flap title ─────────────────────────────────────────────────────
+
+def test_switchboard_title_letters(lab_html: str) -> None:
+    matches = re.findall(r'data-target="([^"]+)"', lab_html)
+    # First 11 letters are the title; trailing ones may belong to scenes.
+    title_letters = "".join(matches[:11])
+    assert title_letters == "switchboard", title_letters
+
+
+def test_scramble_logic_present(lab_script: str) -> None:
+    assert "scrambleSwitchboard" in lab_script
+    assert "mouseenter" in lab_script
+    assert "settled" in lab_script and "scrambling" in lab_script
+
+
+# ─── scenes ───────────────────────────────────────────────────────────────
+
+EXPECTED_SCENES = [
+    "x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle", "pq", "stack",
+]
+
+
+def test_scene_order_matches(lab_script: str) -> None:
+    m = re.search(r"SCENE_ORDER\s*=\s*\[([^\]]+)\]", lab_script)
+    assert m, "SCENE_ORDER array not found"
+    order = re.findall(r'"([^"]+)"', m.group(1))
+    assert order == EXPECTED_SCENES, order
+
+
+def test_every_scene_has_definition(lab_script: str) -> None:
+    for scene_id in EXPECTED_SCENES:
+        assert f"SCENES.{scene_id} = {{" in lab_script, f"SCENES.{scene_id} missing"
+        # each should have a name and short label
+        block_m = re.search(
+            rf"SCENES\.{scene_id}\s*=\s*{{[^}}]*?id:\s*\"{scene_id}\".*?name:\s*\"([^\"]+)\".*?short:\s*\"([^\"]+)\"",
+            lab_script, re.DOTALL,
+        )
+        assert block_m, f"scene {scene_id} missing name/short"
+        name, short = block_m.group(1), block_m.group(2)
+        assert name and short, f"scene {scene_id} has empty name or short"
+
+
+def test_scene_short_codes_are_zero_padded(lab_script: str) -> None:
+    shorts = re.findall(r'short:\s*"(\d+)"', lab_script)
+    assert len(shorts) == len(EXPECTED_SCENES), shorts
+    for s in shorts:
+        assert len(s) == 2 and s.isdigit(), s
+
+
+# ─── cast ─────────────────────────────────────────────────────────────────
+
+def test_named_cast_includes_team(lab_script: str) -> None:
+    for name in ("Patty", "Abhi", "Tridib"):
+        assert f'name: "{name}"' in lab_script, f"agent display name {name!r} missing"
+
+
+def test_no_stale_old_names_in_captions(lab_script: str) -> None:
+    """Bob/Eli/Gus should have been swapped out everywhere they were
+    rendered to the user."""
+    # Inspect only string literals (caption / log / desc), not identifiers.
+    rendered = re.findall(r'"((?:[^"\\]|\\.)*)"', lab_script)
+    bag = " ".join(rendered)
+    for stale in ("Bob ", " Eli ", " Gus ", "Bob's", "Eli's", "Gus's"):
+        assert stale not in bag, f"stale name fragment still visible: {stale!r}"
+
+
+# ─── home page link ───────────────────────────────────────────────────────
+
+def test_home_links_to_lab(home_html: str) -> None:
+    assert 'href="./agents-demo.html"' in home_html, "home page missing lab link"
+
+
+def test_lab_links_back_to_home(lab_html: str) -> None:
+    assert 'href="./index.html"' in lab_html
+
+
+# ─── JS syntax ────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_js_has_no_syntax_errors(lab_script: str) -> None:
+    """Run the embedded script through ``node --check``.
+
+    We pass it as ``module`` syntax via a temp ``.mjs`` so top-level returns
+    aren't an issue. The script is wrapped in an IIFE so it parses standalone.
+    """
+    with tempfile.NamedTemporaryFile("w", suffix=".mjs", delete=False) as f:
+        f.write(lab_script)
+        path = f.name
+    try:
+        proc = subprocess.run(
+            ["node", "--check", path],
+            capture_output=True, text=True, check=False, timeout=15,
+        )
+    finally:
+        Path(path).unlink(missing_ok=True)
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+
+# ─── tooltip + hover affordances ──────────────────────────────────────────
+
+def test_tooltip_wired(lab_script: str) -> None:
+    assert "renderTooltip" in lab_script
+    assert "ttEl.classList.add(\"show\")" in lab_script
+
+
+def test_hover_ripple_and_scale(lab_script: str) -> None:
+    # ripple state + hover ease are both required by the new hover treatment
+    assert "_ripples" in lab_script
+    assert "_hoverEase" in lab_script

--- a/web/SCENES.md
+++ b/web/SCENES.md
@@ -1,0 +1,173 @@
+# Adding a scene to the agent-payments lab
+
+The lab (`web/agents-demo.html`) is a single static HTML file, no build
+step. Each "scene" is a self-contained object you append to the
+`SCENES` registry plus an entry in `SCENE_GROUPS`. Hot-swap any time.
+
+You don't need permission to add one — open a PR.
+
+## What a scene looks like
+
+```js
+SCENES.myScene = {
+  // Required ----------------------------------------------------------
+  id: "myScene",           // matches SCENES key, used in URL slugs / tests
+  name: "My scene",        // shown on the pill button
+  short: "16",             // two-digit number shown in the pill prefix
+  desc: "Short HTML description shown in the left sidebar.",
+
+  // enter() is called every time the scene activates. Reset agent
+  // balances, mark agents visible, set initial caption + log.
+  enter() {
+    setVisible(["bob", "eli"]);
+    A.bob.balance = 10; A.eli.balance = 0;
+    this.layout();
+    this.phase = 0; this.cool = 50;
+    setCaption("step 1 / 3", "<strong>Patty</strong> is about to call Abhi.");
+    log(`<span class="info">myScene</span> scene loaded`);
+  },
+
+  // layout() runs on enter() and whenever the window resizes. Positions
+  // are stage-relative; W and H are the canvas width and height.
+  layout() {
+    A.bob.pos = { x: W * 0.25, y: H * 0.5 };
+    A.eli.pos = { x: W * 0.75, y: H * 0.5 };
+  },
+
+  // tick(t) runs every frame the scene is active and not paused. Drive
+  // your scene state machine here. `this.cool` is a built-in cooldown
+  // pattern — set it to a tick count to gate the next phase.
+  tick(t) {
+    if (this.cool > 0) { this.cool--; return; }
+    if (this.phase === 0) {
+      emit("bob", "eli", { kind: "offer", label: "1.00 USDC",
+        amount: 1.0, speed: 0.02,
+        onArrive: () => {
+          A.bob.balance -= 1; A.eli.balance += 1;
+          jobs++; jobsEl.textContent = jobs;
+        }});
+      log(`Patty → Abhi: 1.00 USDC`);
+      setCaption("step 2 / 3", "Payment in flight.");
+      this.phase = 1; this.cool = 80;
+    } else if (this.phase === 1) {
+      setCaption("step 3 / 3", "Settled. Loop resets.");
+      this.phase = 2; this.cool = 160;
+    } else {
+      A.bob.balance = 10; A.eli.balance = 0;
+      this.phase = 0; this.cool = 60;
+    }
+  },
+
+  // Optional ----------------------------------------------------------
+  drawUnderlay(ctx, W, H) { /* behind agents */ },
+  drawChannels(ctx)        { /* lines between agents */ },
+  drawOverlay(ctx, W, H)   { /* labels, badges, progress bars */ },
+  onAgentClick(agent)      { /* respond to a click on an agent */ },
+};
+```
+
+Then add the id to a group in `SCENE_GROUPS`:
+
+```js
+{ label: "use cases", ids: ["taxi","cafe","delivery","split","ethEscrow","subscribe","myScene"] },
+```
+
+That's it. Reload `agents-demo.html` and your scene appears in the pill bar.
+
+## Agent registry
+
+All agents live in `const A = {...}` at the top of the script. Each
+has a `kind` (`human` / `bot` / `contract`) that drives its shape
+(squircle / octagon / hex) and a `wallet` (`agentic` / `hitl` /
+`treasury` / `provider` / `oracle` / `contract`) that drives its
+outer-ring color.
+
+Other agent fields worth knowing about:
+
+| field         | purpose                                                     |
+| ------------- | ----------------------------------------------------------- |
+| `hue`         | base color for the signature gradient and halo (0–360)      |
+| `protocols`   | string array — shown in the tooltip as pills (x402, MPP, …) |
+| `sigAlg`      | signature algorithm label shown in the tooltip              |
+| `priority`    | `"high"` / `"medium"` / `"low"` — auction scoring           |
+| `radius`      | drawn size (default 32)                                     |
+| `balance`     | live USDC (or ETH in the eth-escrow scene) balance          |
+| `dailyCap`    | spend cap; tooltip + gas_budget-style enforcement           |
+
+Add new agents inline in `A`, or attach to `A` from inside your
+scene's `enter()` if it's scene-local. Either works.
+
+## Packets
+
+Use `emit(fromId, toId, opts)` to send a packet between two agents.
+Common kinds and what they render as:
+
+| kind      | head color | typical use                                  |
+| --------- | ---------- | -------------------------------------------- |
+| `offer`   | white      | PaymentOffer / call                          |
+| `proof`   | green      | PaymentProof / settled receipt               |
+| `request` | blue       | RPC / HTTP-style request                     |
+| `bid`     | yellow     | marketplace bid                              |
+| `data`    | magenta    | signed data, deliverable, oracle response    |
+| `refund`  | red        | refund or rejection                          |
+| `stream`  | agent hue  | per-chunk micropayment                       |
+
+`opts.onArrive` runs when the packet head hits the recipient — use it
+to mutate balances, log, or emit a follow-up packet.
+
+## Cast — when to use whom
+
+The three protagonists you'll probably reach for:
+
+- **Patty** (`A.bob`) — the human user. Buyer side. Has an agentic
+  wallet with caps.
+- **Abhi** (`A.eli`) — the human service operator. Owns the café and
+  the inference service; also Patty's counterparty in the ETH escrow
+  and subscription scenes.
+- **Tridib** (`A.gus`) — the human merchant / restaurateur. Owns Spice
+  Hub; appears as a payer in split-bill.
+
+Bots/AI agents you can pull from: `alice`, `iris`, `juno`, `chen`
+(oracle), `fina` (treasury), `hana` (embed service). For service
+surfaces: `cafe`, `rest`, `merchant`, `dispatch`. For settlement:
+`escrow`.
+
+Shape conventions:
+- **Human** (squircle): Patty, Abhi, Tridib, Sara, Deva, Sai, Kiran
+- **Bot** (octagon): all AI / autonomous agents
+- **Contract** (hex): on-chain entities
+
+## Tests
+
+`tests/test_web_lab.py` runs over the lab on every PR. If you add a
+scene:
+
+1. Append your id to `EXPECTED_SCENES`.
+2. Run `pytest tests/test_web_lab.py -v` locally.
+3. The suite also runs `node --check` on the embedded script if
+   `node` is on PATH. Keep it clean.
+
+## Style guidance
+
+- **Caption every phase.** The caption text is the story; the
+  animation just illustrates it. If a viewer pauses, the caption
+  should still make sense.
+- **Don't over-animate.** The eye should always know which agent is
+  acting. A pulse, a packet, a state change — one beat at a time.
+- **Hue per agent, not per scene.** Don't recolor existing agents;
+  pick a new `hue` if you introduce a new one.
+- **Keep scenes ~80–250 lines.** Beyond that, factor helpers out into
+  the shared block above `SCENES.x402`.
+
+## Bigger ideas wanted
+
+- **Subscription with auto-pause** when usage drops (mirror of #15).
+- **IoT meter** — bot-to-bot recurring micropayments, no humans.
+- **Insurance claim** with parameterized payout via oracle.
+- **Royalty stream** to ML model owners on each inference.
+- **Refund dispute** — the unhappy path past challenge_period.
+- **KYC handshake** — verify-once, cite-many for repeat payments.
+- **Cross-chain settlement** — bridge → escrow → release.
+
+PRs welcome. If you're not sure where a scene belongs, file an issue
+or DM @abhicris.

--- a/web/agents-demo.html
+++ b/web/agents-demo.html
@@ -23,10 +23,34 @@
   header { padding: 12px 24px; border-bottom: 1px solid var(--border);
     display: flex; justify-content: space-between; align-items: center; gap: 12px;
     flex-wrap: wrap; }
-  header h1 { margin: 0; font-size: 14px; font-weight: 500; color: var(--muted); letter-spacing: 0.02em; }
-  header h1 .name { color: var(--fg); font-weight: 600; }
+  header h1 { margin: 0; font-size: 14px; font-weight: 500; color: var(--muted);
+    letter-spacing: 0.02em; display: flex; align-items: center; gap: 10px; }
   header .crumbs { color: var(--muted-2); font-size: 11px; }
   header .crumbs a { color: var(--muted-2); }
+
+  /* ─── split-flap switchboard title ──────────────────────────────────── */
+  .sb-title { display: inline-flex; gap: 1px; font-family: var(--mono);
+    font-weight: 600; font-size: 15px; cursor: pointer; user-select: none;
+    padding: 6px 10px 8px 10px; border-radius: 6px;
+    background: linear-gradient(180deg, #0f1216 0%, #13161b 100%);
+    border: 1px solid var(--border);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.03), 0 1px 0 rgba(0,0,0,0.3); }
+  .sb-char { display: inline-block; position: relative; min-width: 0.78em;
+    text-align: center; color: var(--fg); padding-top: 6px;
+    transition: color 0.15s, transform 0.15s, text-shadow 0.2s; }
+  .sb-char::before {                       /* LED dot above each char */
+    content: ""; position: absolute; top: 0; left: 50%;
+    width: 3px; height: 3px; border-radius: 50%;
+    background: var(--muted-2); transform: translateX(-50%);
+    transition: background 0.2s, box-shadow 0.2s; }
+  .sb-char.settled {
+    color: var(--fg); text-shadow: 0 0 8px rgba(96, 165, 250, 0.25); }
+  .sb-char.settled::before {
+    background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+  .sb-char.scrambling {
+    color: var(--accent); transform: translateY(-1px); }
+  .sb-char.scrambling::before { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+  .sb-tag { color: var(--muted); font-weight: 400; font-size: 12px; }
 
   .scene-bar { display: flex; gap: 4px; padding: 8px 24px; border-bottom: 1px solid var(--border);
     background: var(--panel-2); overflow-x: auto; }
@@ -109,6 +133,22 @@
     background: var(--panel); border: 1px solid var(--border); font-size: 10px;
     color: var(--muted); margin: 0 3px; font-family: var(--mono); }
 
+  .tt { position: fixed; pointer-events: none; z-index: 50;
+    background: rgba(13, 16, 21, 0.94); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 10px; font-size: 11px; min-width: 180px;
+    opacity: 0; transform: translateY(-2px);
+    transition: opacity 0.12s, transform 0.12s;
+    box-shadow: 0 6px 24px rgba(0,0,0,0.5); }
+  .tt.show { opacity: 1; transform: translateY(0); }
+  .tt .ttname { font-weight: 600; font-size: 12px; color: var(--fg); }
+  .tt .ttrole { color: var(--muted); font-size: 10px; margin-bottom: 6px; }
+  .tt .ttkind { display: inline-block; padding: 1px 5px; border-radius: 3px;
+    border: 1px solid; font-size: 10px; font-family: var(--mono); margin-bottom: 6px; }
+  .tt dl { margin: 4px 0 0 0; display: grid; grid-template-columns: auto 1fr;
+    gap: 2px 8px; font-family: var(--mono); font-size: 10px; }
+  .tt dt { color: var(--muted-2); }
+  .tt dd { margin: 0; color: var(--fg); }
+
   .approve { position: absolute; pointer-events: auto;
     background: var(--panel); border: 1px solid var(--warn); color: var(--warn);
     border-radius: 6px; padding: 5px 10px; font: inherit; font-size: 10px;
@@ -131,7 +171,12 @@
 <body>
 
 <header>
-  <h1><span class="name">switchboard</span> · agent payments lab</h1>
+  <h1>
+    <span class="sb-title" id="sbTitle" title="hover to re-patch">
+      <span class="sb-char" data-target="s">s</span><span class="sb-char" data-target="w">w</span><span class="sb-char" data-target="i">i</span><span class="sb-char" data-target="t">t</span><span class="sb-char" data-target="c">c</span><span class="sb-char" data-target="h">h</span><span class="sb-char" data-target="b">b</span><span class="sb-char" data-target="o">o</span><span class="sb-char" data-target="a">a</span><span class="sb-char" data-target="r">r</span><span class="sb-char" data-target="d">d</span>
+    </span>
+    <span class="sb-tag">· agent payments lab</span>
+  </h1>
   <div class="crumbs">
     <a href="./index.html">protocol explorer</a> ·
     <span>vanilla canvas, no build</span>
@@ -159,6 +204,7 @@
       <div><span class="dot" style="background: var(--treasury)"></span><span class="row-key">treasury</span> — high balance, low velocity</div>
       <div><span class="dot" style="background: var(--provider)"></span><span class="row-key">provider</span> — sells work</div>
       <div><span class="dot" style="background: var(--oracle)"></span><span class="row-key">oracle</span> — sells data</div>
+      <div><span class="dot" style="background: var(--accent)"></span><span class="row-key">contract / repo</span> — hex shape</div>
     </div>
   </aside>
 
@@ -182,6 +228,7 @@
 
 </div>
 
+<div class="tt" id="tooltip"></div>
 <footer><a href="https://github.com/kcolbchain/switchboard">source</a></footer>
 
 <script>
@@ -239,12 +286,12 @@
 
   const A = {
     alice:  makeAgent({ id: "alice",   name: "Alice",   role: "researcher",        wallet: "agentic",  hue: 195, balance: 8.0,  dailyCap: 12 }),
-    bob:    makeAgent({ id: "bob",     name: "Bob",     role: "data buyer",        wallet: "agentic",  hue: 145, balance: 6.0,  dailyCap: 10 }),
+    bob:    makeAgent({ id: "bob",     name: "Patty",   role: "data buyer",        wallet: "agentic",  hue: 145, balance: 6.0,  dailyCap: 10 }),
     chen:   makeAgent({ id: "chen",    name: "Chen",    role: "price oracle",      wallet: "oracle",   hue: 295, balance: 30,   dailyCap: 80, radius: 38 }),
     deva:   makeAgent({ id: "deva",    name: "Deva",    role: "trader",            wallet: "hitl",     hue:  40, balance: 4.0,  dailyCap: 25 }),
-    eli:    makeAgent({ id: "eli",     name: "Eli",     role: "inference service", wallet: "provider", hue: 152, balance: 1.0,  dailyCap: 50, radius: 36 }),
+    eli:    makeAgent({ id: "eli",     name: "Abhi",    role: "inference service", wallet: "provider", hue: 152, balance: 1.0,  dailyCap: 50, radius: 36 }),
     fina:   makeAgent({ id: "fina",    name: "Fina",    role: "treasury",          wallet: "treasury", hue: 250, balance: 80,   dailyCap: 90, radius: 44 }),
-    gus:    makeAgent({ id: "gus",     name: "Gus",     role: "image-gen service", wallet: "provider", hue:   8, balance: 0.5,  dailyCap: 40, radius: 36 }),
+    gus:    makeAgent({ id: "gus",     name: "Tridib",  role: "image-gen service", wallet: "provider", hue:   8, balance: 0.5,  dailyCap: 40, radius: 36 }),
     hana:   makeAgent({ id: "hana",    name: "Hana",    role: "embed service",     wallet: "provider", hue: 330, balance: 0.8,  dailyCap: 40, radius: 36 }),
     iris:   makeAgent({ id: "iris",    name: "Iris",    role: "buyer",             wallet: "agentic",  hue: 180, balance: 6,    dailyCap: 12 }),
     juno:   makeAgent({ id: "juno",    name: "Juno",    role: "buyer",             wallet: "agentic",  hue:  90, balance: 5,    dailyCap: 10 }),
@@ -273,14 +320,26 @@
   }
 
   // ─── interaction ──────────────────────────────────────────────────────────
+  const ttEl = document.getElementById("tooltip");
   cvs.addEventListener("mousemove", e => {
     const r = cvs.getBoundingClientRect();
     mouse.x = e.clientX - r.left;
     mouse.y = e.clientY - r.top;
+    const prevHover = hoverId;
     hoverId = pickAgent(mouse.x, mouse.y);
+    if (hoverId && hoverId !== prevHover) {
+      // kick a ripple wave on first frame of hover
+      const a = A[hoverId];
+      a._ripples = a._ripples || [];
+      a._ripples.push({ t: 0, r: a.radius });
+    }
     renderInfo();
+    renderTooltip(e.clientX, e.clientY);
   });
-  cvs.addEventListener("mouseleave", () => { hoverId = null; renderInfo(); });
+  cvs.addEventListener("mouseleave", () => {
+    hoverId = null; renderInfo();
+    ttEl.classList.remove("show");
+  });
   cvs.addEventListener("click", () => {
     if (!hoverId || !currentScene.onAgentClick) return;
     currentScene.onAgentClick(A[hoverId]);
@@ -352,9 +411,25 @@
   }
 
   function drawAgent(a) {
-    const { x, y } = a.pos, r = a.radius;
+    const { x, y } = a.pos;
     const hovered = (a.id === hoverId);
+    // hover scale-up: smooth ease toward 1.12 when hovered, 1.0 otherwise
+    a._hoverEase = (a._hoverEase ?? 1) + ((hovered ? 1.12 : 1.0) - (a._hoverEase ?? 1)) * 0.18;
+    const r = a.radius * a._hoverEase;
     const balanceRatio = Math.min(1, a.balance / Math.max(1, a.dailyCap));
+
+    // hover ripples — expanding rings, fade as they grow
+    if (a._ripples) {
+      for (let i = a._ripples.length - 1; i >= 0; i--) {
+        const rp = a._ripples[i];
+        rp.t += 0.04;
+        if (rp.t >= 1) { a._ripples.splice(i, 1); continue; }
+        const rr = a.radius + rp.t * 50;
+        ctx.strokeStyle = hsla(a.hue, 90, 65, (1 - rp.t) * 0.5);
+        ctx.lineWidth = 2 * (1 - rp.t);
+        ctx.beginPath(); ctx.arc(x, y, rr, 0, Math.PI*2); ctx.stroke();
+      }
+    }
 
     // halo
     if (a.state === "active" || a.state === "paying" || a.state === "listening") {
@@ -457,19 +532,21 @@
     }
     ctx.closePath();
     const inner = ctx.createRadialGradient(x, y, 1, x, y, r);
-    inner.addColorStop(0,  hsla(a.hue, 50, 50, 0.45));
-    inner.addColorStop(1,  hsla(a.hue, 30, 25, 0.85));
+    inner.addColorStop(0,  hsla(a.hue, 60, 55, 0.5));
+    inner.addColorStop(1,  hsla(a.hue, 35, 28, 0.85));
     ctx.fillStyle = inner; ctx.fill();
     ctx.strokeStyle = walletColor(a.wallet); ctx.lineWidth = 1.6; ctx.stroke();
-    // little lock icon
-    ctx.strokeStyle = hsla(a.hue, 60, 80, 0.7);
-    ctx.lineWidth = 1.4;
-    ctx.beginPath();
-    ctx.rect(x - 5, y - 2, 10, 8);
-    ctx.moveTo(x - 3, y - 2); ctx.lineTo(x - 3, y - 5);
-    ctx.arc(x, y - 5, 3, Math.PI, 0);
-    ctx.lineTo(x + 3, y - 2);
-    ctx.stroke();
+    // Only draw the lock glyph for actual escrow contracts, not repo nodes.
+    if (a.id === "escrow" || a.id === "aeo_repo") {
+      ctx.strokeStyle = hsla(a.hue, 60, 80, 0.7);
+      ctx.lineWidth = 1.4;
+      ctx.beginPath();
+      ctx.rect(x - 5, y - 2, 10, 8);
+      ctx.moveTo(x - 3, y - 2); ctx.lineTo(x - 3, y - 5);
+      ctx.arc(x, y - 5, 3, Math.PI, 0);
+      ctx.lineTo(x + 3, y - 2);
+      ctx.stroke();
+    }
     ctx.restore();
   }
 
@@ -585,6 +662,42 @@
     `;
   }
 
+  function renderTooltip(clientX, clientY) {
+    if (!hoverId) { ttEl.classList.remove("show"); return; }
+    const a = A[hoverId];
+    const walletDesc = {
+      agentic:  "autonomous, auto-pays under cap",
+      hitl:     "human approves spend above threshold",
+      treasury: "rebalancer / fleet funder",
+      provider: "sells work, receives payments",
+      oracle:   "sells signed data, pay-per-query",
+      contract: "on-chain settlement (AgentEscrow.sol)",
+    }[a.wallet] || "";
+    const wColor = walletColor(a.wallet);
+    ttEl.innerHTML = `
+      <div class="ttname">${a.name}</div>
+      <div class="ttrole">${a.role}</div>
+      <span class="ttkind" style="color:${wColor};border-color:${wColor}">${a.wallet}</span>
+      <div style="color:var(--muted);font-size:10px;margin-bottom:4px">${walletDesc}</div>
+      <dl>
+        <dt>balance</dt><dd>${a.balance.toFixed(2)} USDC</dd>
+        <dt>daily cap</dt><dd>${a.dailyCap.toFixed(0)} USDC</dd>
+        <dt>spent</dt><dd>${a.spent.toFixed(2)} USDC</dd>
+        <dt>state</dt><dd>${a.state}</dd>
+        <dt>sig hue</dt><dd>h${a.hue}°</dd>
+      </dl>
+    `;
+    // place near cursor, flip when near right edge
+    const pad = 14;
+    let tx = clientX + pad, ty = clientY + pad;
+    const rect = ttEl.getBoundingClientRect();
+    if (tx + 220 > window.innerWidth) tx = clientX - 220 - pad;
+    if (ty + 200 > window.innerHeight) ty = clientY - rect.height - pad;
+    ttEl.style.left = tx + "px";
+    ttEl.style.top  = ty + "px";
+    ttEl.classList.add("show");
+  }
+
   function log(html) {
     const row = document.createElement("div");
     row.className = "row";
@@ -657,7 +770,7 @@
       A.bob.balance = 6; A.bob.spent = 0;
       A.eli.balance = 1;
       this.layout(); this.phase = 0; this.cool = 0;
-      setCaption("step 1 / 4", "<code>GET /inference</code> — <strong>Bob</strong> calls <strong>Eli</strong>'s endpoint cold, no <code>X-Payment-Proof</code> header attached.");
+      setCaption("step 1 / 4", "<code>GET /inference</code> — <strong>Patty</strong> calls <strong>Abhi</strong>'s endpoint cold, no <code>X-Payment-Proof</code> header attached.");
       log(`<span class="info">x402</span> scene loaded`);
     },
     layout() {
@@ -668,23 +781,23 @@
       if (this.cool > 0) { this.cool--; return; }
       if (this.phase === 0 && t % 220 === 30) {
         emit("bob", "eli", { kind: "request", label: "GET /infer", speed: 0.018 });
-        log(`Bob → Eli: <code>GET /inference</code>`);
+        log(`Patty → Abhi: <code>GET /inference</code>`);
         this.phase = 1; this.cool = 60;
       } else if (this.phase === 1) {
         emit("eli", "bob", { kind: "request", label: "402 + accepts[]", speed: 0.018 });
-        log(`Eli → Bob: <span class="warn">402 Payment Required</span> · 0.001 USDC`);
-        setCaption("step 2 / 4", "Eli returns <code>402 Payment Required</code> with an <code>accepts[]</code> envelope describing the price and recipient.");
+        log(`Abhi → Patty: <span class="warn">402 Payment Required</span> · 0.001 USDC`);
+        setCaption("step 2 / 4", "Abhi returns <code>402 Payment Required</code> with an <code>accepts[]</code> envelope describing the price and recipient.");
         this.phase = 2; this.cool = 80;
       } else if (this.phase === 2) {
         emit("bob", "eli", { kind: "offer", label: "X-Payment-Proof", amount: 0.001, speed: 0.018,
           onArrive: () => { A.bob.balance -= 0.001; A.eli.balance += 0.001; A.bob.spent += 0.001; }});
-        log(`Bob → Eli: <code>X-Payment-Proof</code> 0.001 USDC`);
-        setCaption("step 3 / 4", "Bob signs an <code>X-Payment-Proof</code> header and retries. Payment settles on-chain in the background.");
+        log(`Patty → Abhi: <code>X-Payment-Proof</code> 0.001 USDC`);
+        setCaption("step 3 / 4", "Patty signs an <code>X-Payment-Proof</code> header and retries. Payment settles on-chain in the background.");
         this.phase = 3; this.cool = 80;
       } else if (this.phase === 3) {
         emit("eli", "bob", { kind: "proof", label: "200 OK", speed: 0.018 });
-        log(`Eli → Bob: <span class="ok">200 OK</span> · inference result`);
-        setCaption("step 4 / 4", "Eli verifies the proof, serves <code>200 OK</code> with the inference result. Loop repeats — every paid call costs Bob 0.001 USDC.");
+        log(`Abhi → Patty: <span class="ok">200 OK</span> · inference result`);
+        setCaption("step 4 / 4", "Abhi verifies the proof, serves <code>200 OK</code> with the inference result. Loop repeats — every paid call costs Patty 0.001 USDC.");
         jobs++; jobsEl.textContent = jobs;
         this.phase = 0; this.cool = 140;
       }
@@ -706,7 +819,7 @@
       A.deva.balance = 10; A.hana.balance = 0.5;
       this.layout();
       this.phase = 0; this.cool = 60; this.block = 0; this.refundBlock = 0;
-      setCaption("step 1 / 5", "Two parallel flows. <strong>Alice → Gus</strong> follows the happy path. <strong>Deva → Hana</strong> will demonstrate the refund path.");
+      setCaption("step 1 / 5", "Two parallel flows. <strong>Alice → Tridib</strong> follows the happy path. <strong>Deva → Hana</strong> will demonstrate the refund path.");
       log(`<span class="info">escrow</span> scene loaded · two parallel flows`);
     },
     layout() {
@@ -753,10 +866,10 @@
         setCaption("step 2 / 5", "<strong>Alice</strong> calls <code>createPayment()</code>, locking 2.5 USDC in the <span class=\"pill\">Escrow</span> contract.");
         this.phase = 1; this.cool = 80;
       } else if (this.phase === 1) {
-        // Gus delivers work (data packet to Alice)
+        // Tridib delivers work (data packet to Alice)
         emit("gus", "alice", { kind: "data", label: "deliverable", speed: 0.016 });
-        log(`Gus → Alice: deliverable submitted`);
-        setCaption("step 3 / 5", "<strong>Gus</strong> performs the work off-chain and delivers the artifact.");
+        log(`Tridib → Alice: deliverable submitted`);
+        setCaption("step 3 / 5", "<strong>Tridib</strong> performs the work off-chain and delivers the artifact.");
         this.phase = 2; this.cool = 80;
       } else if (this.phase === 2) {
         // Alice confirms, escrow releases to Gus
@@ -765,8 +878,8 @@
             emit("escrow", "gus", { kind: "proof", label: "released 2.5", amount: 2.5, speed: 0.018,
               onArrive: () => { A.escrow.balance -= 2.5; A.gus.balance += 2.5; jobs++; jobsEl.textContent = jobs; }});
           }});
-        log(`Alice → Escrow: <code>confirmPayment(request_id)</code> · <span class="ok">released to Gus</span>`);
-        setCaption("step 4 / 5", "Alice calls <code>confirmPayment()</code> → escrow releases 2.5 USDC to Gus.");
+        log(`Alice → Escrow: <code>confirmPayment(request_id)</code> · <span class="ok">released to Tridib</span>`);
+        setCaption("step 4 / 5", "Alice calls <code>confirmPayment()</code> → escrow releases 2.5 USDC to Tridib.");
         this.phase = 3; this.cool = 100;
         // Kick off refund-path scenario
         this.refundBlock = this.block + 20;
@@ -798,7 +911,7 @@
     id: "stream",
     name: "Streaming micropayments",
     short: "03",
-    desc: "Multi-party / streaming pay: Alice opens a budget-capped session with Eli, and pays per chunk as inference tokens stream back. Like x402's <code>STREAMING</code> scheme — small, fast, capped.",
+    desc: "Multi-party / streaming pay: Alice opens a budget-capped session with Abhi, and pays per chunk as inference tokens stream back. Like x402's <code>STREAMING</code> scheme — small, fast, capped.",
     enter() {
       setVisible(["alice", "eli"]);
       A.alice.balance = 5; A.alice.spent = 0; A.alice.dailyCap = 5;
@@ -806,7 +919,7 @@
       this.layout();
       this.tokensServed = 0;
       this.budget = 5.0;
-      setCaption("step 1 / 2", "Session opened. Cap is 5 USDC. Each chunk = 0.02 USDC. Alice's balance drains as Eli's grows; session auto-closes at cap.");
+      setCaption("step 1 / 2", "Session opened. Cap is 5 USDC. Each chunk = 0.02 USDC. Alice's balance drains as Abhi's grows; session auto-closes at cap.");
       log(`<span class="info">stream</span> scene loaded · cap 5.00 USDC, 0.02 USDC/chunk`);
     },
     layout() {
@@ -859,7 +972,7 @@
     id: "auction",
     name: "AI compute auction",
     short: "04",
-    desc: "Marketplace flow. <strong>Iris</strong> broadcasts a job (transcribe 10 minutes of audio). <strong>Eli</strong>, <strong>Gus</strong>, and <strong>Hana</strong> bid. Lowest bid wins; payment goes through escrow.",
+    desc: "Marketplace flow. <strong>Iris</strong> broadcasts a job (transcribe 10 minutes of audio). <strong>Abhi</strong>, <strong>Tridib</strong>, and <strong>Hana</strong> bid. Lowest bid wins; payment goes through escrow.",
     enter() {
       setVisible(["iris", "eli", "gus", "hana", "escrow"]);
       A.iris.balance = 12; A.iris.spent = 0;
@@ -1029,7 +1142,7 @@
     id: "oracle",
     name: "On-chain oracle pull",
     short: "07",
-    desc: "AI-on-chain pattern. <strong>Chen</strong> sells signed price quotes. <strong>Alice</strong>, <strong>Bob</strong>, and <strong>Iris</strong> pull on demand and pay per-query. Signed responses fold into the PQ-signed-envelope work tracked in <a href=\"https://github.com/kcolbchain/switchboard/issues/33\">#33</a>.",
+    desc: "AI-on-chain pattern. <strong>Chen</strong> sells signed price quotes. <strong>Alice</strong>, <strong>Patty</strong>, and <strong>Iris</strong> pull on demand and pay per-query. Signed responses fold into the PQ-signed-envelope work tracked in <a href=\"https://github.com/kcolbchain/switchboard/issues/33\">#33</a>.",
     enter() {
       setVisible(["chen", "alice", "bob", "iris"]);
       A.chen.balance = 12;
@@ -1071,8 +1184,217 @@
     },
   };
 
+  // — Scene 8: PQ-signed envelopes (our proposal) ————————————————————————
+  SCENES.pq = {
+    id: "pq",
+    name: "PQ-signed envelopes",
+    short: "08",
+    desc: "Our proposal — every <code>PaymentOffer</code> / <code>PaymentProof</code> carries an application-layer post-quantum signature (default <strong>ML-DSA-65</strong>; <strong>hybrid</strong> mode pairs it with ECDSA). Receivers verify <em>before</em> paying. Tracked in <a href=\"https://github.com/kcolbchain/switchboard/issues/33\">#33</a>.",
+    enter() {
+      setVisible(["bob", "eli", "deva"]);
+      A.bob.balance = 8;  A.bob.spent = 0;
+      A.eli.balance = 1;
+      A.deva.balance = 8; A.deva.spent = 0;
+      this.layout();
+      this.phase = 0; this.cool = 50; this.mode = "ml-dsa-65";
+      setCaption("step 1 / 4", "<strong>Patty</strong> constructs a <code>PaymentOffer</code>, signs the canonical transcript with her PQ secret key, attaches the signature.");
+      log(`<span class="info">pq</span> scene loaded · default alg ml-dsa-65`);
+    },
+    layout() {
+      A.bob.pos  = { x: W * 0.22, y: H * 0.38 };
+      A.eli.pos  = { x: W * 0.78, y: H * 0.5 };
+      A.deva.pos = { x: W * 0.22, y: H * 0.72 };
+    },
+    drawOverlay(ctx, W, H) {
+      // signing/verifying glyphs near agents in flight phases
+      if (this.signing) {
+        const a = A.bob;
+        const ang = (tick * 0.18) % (Math.PI * 2);
+        for (let i = 0; i < 6; i++) {
+          const aa = ang + (i / 6) * Math.PI * 2;
+          const px = a.pos.x + Math.cos(aa) * (a.radius + 16);
+          const py = a.pos.y + Math.sin(aa) * (a.radius + 16);
+          ctx.fillStyle = "rgba(96, 165, 250, 0.85)";
+          ctx.beginPath(); ctx.arc(px, py, 2, 0, Math.PI*2); ctx.fill();
+        }
+        ctx.fillStyle = "rgba(96, 165, 250, 0.9)";
+        ctx.font = "10px ui-monospace, Menlo, monospace";
+        ctx.textAlign = "center";
+        ctx.fillText("signing…", a.pos.x, a.pos.y - a.radius - 18);
+      }
+      if (this.verifying) {
+        const a = A.eli;
+        const ang = (-tick * 0.22) % (Math.PI * 2);
+        ctx.strokeStyle = "rgba(52, 211, 153, 0.7)";
+        ctx.lineWidth = 1.5; ctx.setLineDash([4, 4]);
+        ctx.beginPath();
+        ctx.arc(a.pos.x, a.pos.y, a.radius + 12, ang, ang + Math.PI * 1.5);
+        ctx.stroke(); ctx.setLineDash([]);
+        ctx.fillStyle = "rgba(52, 211, 153, 0.9)";
+        ctx.font = "10px ui-monospace, Menlo, monospace";
+        ctx.textAlign = "center";
+        ctx.fillText("verifying ml-dsa-65…", a.pos.x, a.pos.y - a.radius - 18);
+      }
+      // legend strip near top
+      const lx = W * 0.5;
+      ctx.fillStyle = "rgba(231, 233, 238, 0.7)";
+      ctx.font = "10px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText("⬢ signed envelope    ⬡ unsigned (rejected in strict mode)", lx, 18);
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      if (this.phase === 0) {
+        this.signing = true; this.cool = 60;
+        this.phase = 1;
+        return;
+      }
+      if (this.phase === 1) {
+        this.signing = false;
+        const amount = 0.5;
+        emit("bob", "eli", { kind: "offer", label: "ml-dsa-65 ✓", amount, speed: 0.014,
+          onArrive: () => { this.verifying = true; }
+        });
+        log(`Patty → Abhi: <code>PaymentOffer</code> + <span class="info">ml-dsa-65</span> sig (3,309 bytes)`);
+        setCaption("step 2 / 4", "Envelope leaves <strong>Patty</strong> with the PQ signature attached. Comet head + label show <code>ml-dsa-65</code>.");
+        this.phase = 2; this.cool = 80;
+        return;
+      }
+      if (this.phase === 2) {
+        this.verifying = false;
+        emit("eli", "bob", { kind: "proof", label: "verified · 0.5 USDC", amount: 0.5, speed: 0.018,
+          onArrive: () => { A.bob.balance -= 0.5; A.eli.balance += 0.5; jobs++; jobsEl.textContent = jobs; }
+        });
+        log(`<span class="ok">Abhi verified</span> sig vs Patty's pubkey · 200 OK · 0.5 USDC`);
+        setCaption("step 3 / 4", "<strong>Abhi</strong> verifies the signature against Patty's public key <em>before</em> paying. Today's code path can't do this — it has to settle first and inspect the tx hash after.");
+        this.phase = 3; this.cool = 120;
+        return;
+      }
+      if (this.phase === 3) {
+        // Contrast: Deva sends an UNSIGNED offer (strict mode rejects)
+        emit("deva", "eli", { kind: "request", label: "unsigned", amount: 0.5, speed: 0.014,
+          onArrive: () => {
+            log(`<span class="hot">Abhi rejected</span> offer from Deva: signature_alg = "none" (strict mode)`);
+            // bounce-back red refund packet
+            emit("eli", "deva", { kind: "refund", label: "reject", speed: 0.022 });
+          }
+        });
+        setCaption("step 4 / 4", "<strong>Deva</strong> sends an <em>unsigned</em> offer. With <code>X402Middleware.require_signed=True</code> the receiver rejects on principle — no settlement, no leak.");
+        this.phase = 4; this.cool = 180;
+        return;
+      }
+      if (this.phase === 4) {
+        // hybrid demo: ECDSA + ML-DSA-65 stamped twice
+        emit("bob", "eli", { kind: "offer", label: "hybrid (ecdsa + ml-dsa-65)", amount: 0.5, speed: 0.014,
+          onArrive: () => {
+            log(`<span class="ok">hybrid verified</span> · both halves passed (ecdsa + ml-dsa-65)`);
+            emit("eli", "bob", { kind: "proof", label: "200 OK", speed: 0.018,
+              onArrive: () => { A.bob.balance -= 0.5; A.eli.balance += 0.5; jobs++; jobsEl.textContent = jobs; }
+            });
+          }
+        });
+        log(`Patty → Abhi: hybrid envelope (ecdsa + ml-dsa-65)`);
+        setCaption("step 4 / 4", "<strong>Hybrid mode</strong> — two signatures stacked. Verifier requires <em>both</em> to pass. Migration-friendly: classical-only verifiers still see the ECDSA half.");
+        this.phase = 5; this.cool = 200;
+        return;
+      }
+      if (this.phase === 5) {
+        this.phase = 0; this.cool = 100;
+        A.bob.balance = 8; A.eli.balance = 1; A.deva.balance = 8;
+      }
+    },
+  };
+
+  // — Scene 9: stack — coexistence with neighboring repos ————————————————————
+  // Switchboard isn't alone. ZAP, x402, gas-oracle, scout, arka all sit
+  // adjacent. This scene illustrates the data-flow seams.
+  // We extend the agent registry with repo "nodes" rendered with a contract
+  // hex shape but distinct hues + per-repo roles.
+  A.swb       = makeAgent({ id: "swb",       name: "switchboard", role: "agent payments substrate", wallet: "contract", hue: 215, radius: 42, shape: "hex" });
+  A.zap_repo  = makeAgent({ id: "zap_repo",  name: "zap",         role: "zero-alloc binary wire",   wallet: "contract", hue: 285, radius: 32, shape: "hex" });
+  A.arka_repo = makeAgent({ id: "arka_repo", name: "arka",        role: "Rust agent SDK",           wallet: "contract", hue:  25, radius: 32, shape: "hex" });
+  A.scout_repo= makeAgent({ id: "scout_repo",name: "scout",       role: "wallet intel",             wallet: "contract", hue: 165, radius: 32, shape: "hex" });
+  A.gas_repo  = makeAgent({ id: "gas_repo",  name: "gas-oracle",  role: "L2 gas forecasts",         wallet: "contract", hue:  55, radius: 32, shape: "hex" });
+  A.x402_repo = makeAgent({ id: "x402_repo", name: "x402",        role: "upstream HTTP-402 spec",   wallet: "contract", hue: 195, radius: 32, shape: "hex" });
+  A.aeo_repo  = makeAgent({ id: "aeo_repo",  name: "AgentEscrow", role: "on-chain settlement",      wallet: "contract", hue: 250, radius: 30, shape: "hex" });
+
+  SCENES.stack = {
+    id: "stack",
+    name: "Repo coexistence",
+    short: "09",
+    desc: "Switchboard's place in the stack. Arrows are real data-flow seams in the code: <code>zap_transport.py</code> ↔ <a href=\"https://github.com/luxfi/zap\">zap</a>, <code>gas_tracker.py</code> ↔ <a href=\"https://github.com/kcolbchain/gas-oracle\">gas-oracle</a>, <code>x402_middleware.py</code> implements the <a href=\"https://x402.org\">x402</a> spec, etc.",
+    enter() {
+      setVisible(["swb", "zap_repo", "arka_repo", "scout_repo", "gas_repo", "x402_repo", "aeo_repo"]);
+      this.layout();
+      this.cool = 30; this.flows = [];
+      // ascii arrows shown on canvas
+      setCaption("step 1 / 1", "Each repo owns one job. Switchboard composes them: it imports zap for the wire, gas-oracle for budget signals, scout for counterparty intel, and ships the AgentEscrow contract that gives the rails their on-chain teeth. Hover to inspect.");
+      log(`<span class="info">stack</span> scene loaded · 7 nodes`);
+    },
+    layout() {
+      A.swb.pos       = { x: W * 0.5,  y: H * 0.5  };
+      A.zap_repo.pos  = { x: W * 0.78, y: H * 0.28 };
+      A.arka_repo.pos = { x: W * 0.78, y: H * 0.72 };
+      A.scout_repo.pos= { x: W * 0.22, y: H * 0.72 };
+      A.gas_repo.pos  = { x: W * 0.22, y: H * 0.28 };
+      A.x402_repo.pos = { x: W * 0.5,  y: H * 0.18 };
+      A.aeo_repo.pos  = { x: W * 0.5,  y: H * 0.82 };
+    },
+    drawChannels(ctx) {
+      // directional arrows with labels
+      const edges = [
+        { a: "zap_repo",  b: "swb", label: "wire", color: "rgba(240, 171, 252, 0.45)" },
+        { a: "gas_repo",  b: "swb", label: "gas signals", color: "rgba(251, 191, 36, 0.45)" },
+        { a: "x402_repo", b: "swb", label: "implements", color: "rgba(125, 211, 252, 0.45)" },
+        { a: "scout_repo",b: "swb", label: "intel", color: "rgba(52, 211, 153, 0.45)" },
+        { a: "swb", b: "arka_repo", label: "consumer", color: "rgba(96, 165, 250, 0.45)" },
+        { a: "swb", b: "aeo_repo",  label: "ships", color: "rgba(167, 139, 250, 0.45)" },
+      ];
+      ctx.save();
+      ctx.lineWidth = 1.5;
+      for (const e of edges) {
+        const a = A[e.a], b = A[e.b];
+        const dx = b.pos.x - a.pos.x, dy = b.pos.y - a.pos.y;
+        const len = Math.hypot(dx, dy);
+        const ux = dx / len, uy = dy / len;
+        const sx = a.pos.x + ux * (a.radius + 4);
+        const sy = a.pos.y + uy * (a.radius + 4);
+        const ex = b.pos.x - ux * (b.radius + 4);
+        const ey = b.pos.y - uy * (b.radius + 4);
+        ctx.strokeStyle = e.color;
+        ctx.beginPath(); ctx.moveTo(sx, sy); ctx.lineTo(ex, ey); ctx.stroke();
+        // arrowhead
+        const ah = 6;
+        const angle = Math.atan2(uy, ux);
+        ctx.beginPath();
+        ctx.moveTo(ex, ey);
+        ctx.lineTo(ex - ah * Math.cos(angle - 0.4), ey - ah * Math.sin(angle - 0.4));
+        ctx.lineTo(ex - ah * Math.cos(angle + 0.4), ey - ah * Math.sin(angle + 0.4));
+        ctx.closePath(); ctx.fillStyle = e.color; ctx.fill();
+        // label
+        const lx = (sx + ex) / 2, ly = (sy + ey) / 2;
+        ctx.fillStyle = "rgba(231, 233, 238, 0.65)";
+        ctx.font = "10px ui-monospace, Menlo, monospace";
+        ctx.textAlign = "center";
+        ctx.fillText(e.label, lx, ly - 4);
+      }
+      ctx.restore();
+    },
+    tick(t) {
+      // Periodically emit a tiny data dot along each edge for liveliness
+      if (t % 90 === 0) {
+        const edges = [
+          ["zap_repo", "swb"], ["gas_repo", "swb"], ["x402_repo", "swb"],
+          ["scout_repo", "swb"], ["swb", "arka_repo"], ["swb", "aeo_repo"],
+        ];
+        const [a, b] = edges[Math.floor(Math.random() * edges.length)];
+        emit(a, b, { kind: "data", label: "", speed: 0.018 });
+      }
+    },
+  };
+
   // ─── scene registry & switcher ────────────────────────────────────────────
-  const SCENE_ORDER = ["x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle"];
+  const SCENE_ORDER = ["x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle", "pq", "stack"];
 
   function selectScene(id, force) {
     if (!force && currentScene && currentScene.id === id) return;
@@ -1101,9 +1423,40 @@
     sceneBar.appendChild(b);
   });
 
+  // ─── split-flap "switchboard" title ───────────────────────────────────────
+  const SB_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_/";
+  const sbTitle = document.getElementById("sbTitle");
+  const sbLetters = Array.from(sbTitle.querySelectorAll(".sb-char"));
+  const sbTargets = sbLetters.map(c => c.dataset.target);
+  let sbBusy = false;
+
+  function scrambleSwitchboard() {
+    if (sbBusy) return;
+    sbBusy = true;
+    let remaining = sbLetters.length;
+    sbLetters.forEach((c, i) => {
+      c.classList.remove("settled");
+      c.classList.add("scrambling");
+      let ticks = 6 + i * 2;             // stagger: left settles first
+      const id = setInterval(() => {
+        if (--ticks <= 0) {
+          c.textContent = sbTargets[i];
+          c.classList.remove("scrambling");
+          c.classList.add("settled");
+          clearInterval(id);
+          if (--remaining === 0) sbBusy = false;
+          return;
+        }
+        c.textContent = SB_CHARS[Math.floor(Math.random() * SB_CHARS.length)];
+      }, 45);
+    });
+  }
+  sbTitle.addEventListener("mouseenter", scrambleSwitchboard);
+
   // ─── go ───────────────────────────────────────────────────────────────────
   resize();
   selectScene("x402");
+  scrambleSwitchboard();
   requestAnimationFrame(step);
 })();
 </script>

--- a/web/agents-demo.html
+++ b/web/agents-demo.html
@@ -1,0 +1,601 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>switchboard — agentic payments demo</title>
+<meta name="description" content="Interactive canvas demo of agent-to-agent payments. Hover to reveal each agent's signature gradient, click to send a payment, watch human-in-the-loop gates." />
+<style>
+  :root {
+    --bg: #0b0d10; --panel: #13161b; --panel-2: #0f1216; --border: #23272f;
+    --fg: #e7e9ee; --muted: #8a93a3;
+    --accent: #60a5fa; --ok: #34d399; --warn: #fbbf24; --hot: #f87171; --info: #7dd3fc;
+    --agentic: #7dd3fc; --hitl: #fbbf24; --treasury: #a78bfa;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--bg); color: var(--fg);
+    font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    overflow: hidden; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  header { padding: 14px 24px; border-bottom: 1px solid var(--border);
+    display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
+  header h1 { margin: 0; font-size: 16px; font-weight: 600; }
+  header h1 .dot { color: var(--accent); }
+  header .crumbs { color: var(--muted); font-size: 12px; }
+  header .crumbs a { color: var(--muted); }
+  header .crumbs a:hover { color: var(--fg); }
+
+  .layout { display: grid; grid-template-columns: 260px 1fr 280px;
+    height: calc(100vh - 50px); }
+
+  aside { background: var(--panel-2); border-right: 1px solid var(--border);
+    padding: 16px; overflow-y: auto; }
+  aside.right { border-right: none; border-left: 1px solid var(--border); }
+  aside h2 { font-size: 11px; color: var(--muted); text-transform: uppercase;
+    letter-spacing: 0.08em; margin: 0 0 8px 0; }
+  aside h2:not(:first-child) { margin-top: 18px; }
+
+  .legend { font-size: 12px; color: var(--muted); line-height: 1.7; }
+  .legend .dot { display: inline-block; width: 8px; height: 8px;
+    border-radius: 50%; vertical-align: 1px; margin-right: 6px; }
+
+  .agent-info { font-family: var(--mono); font-size: 12px; }
+  .agent-info .name { font-size: 14px; color: var(--fg); font-family: inherit;
+    margin-bottom: 4px; font-family: -apple-system, system-ui, sans-serif; font-weight: 600; }
+  .agent-info .role { color: var(--muted); font-family: -apple-system, system-ui, sans-serif;
+    margin-bottom: 12px; }
+  .agent-info dl { margin: 0; display: grid; grid-template-columns: auto 1fr;
+    gap: 4px 12px; }
+  .agent-info dt { color: var(--muted); }
+  .agent-info dd { margin: 0; color: var(--fg); }
+  .agent-info .bar { height: 4px; background: var(--panel); border-radius: 2px;
+    overflow: hidden; margin-top: 4px; }
+  .agent-info .bar > div { height: 100%; background: var(--ok); }
+  .agent-info .bar.over > div { background: var(--hot); }
+
+  .empty { color: var(--muted); font-style: italic; font-size: 12px; }
+
+  .log { font-family: var(--mono); font-size: 11px; line-height: 1.5; }
+  .log .row { padding: 4px 0; border-bottom: 1px dashed var(--border);
+    display: flex; gap: 8px; }
+  .log .t { color: var(--muted); flex: 0 0 38px; }
+  .log .m { color: var(--fg); flex: 1; word-break: break-word; }
+  .log .ok { color: var(--ok); }
+  .log .warn { color: var(--warn); }
+  .log .hot { color: var(--hot); }
+
+  .stage { position: relative; }
+  canvas { display: block; width: 100%; height: 100%; cursor: crosshair; }
+
+  .stats { position: absolute; top: 12px; left: 12px;
+    background: rgba(13, 16, 21, 0.85); border: 1px solid var(--border);
+    border-radius: 8px; padding: 8px 12px; font-family: var(--mono); font-size: 11px;
+    display: flex; gap: 16px; }
+  .stats .label { color: var(--muted); margin-right: 4px; }
+  .stats .val { color: var(--fg); }
+  .stats .val.ok { color: var(--ok); }
+
+  .help { position: absolute; bottom: 12px; left: 12px;
+    background: rgba(13, 16, 21, 0.85); border: 1px solid var(--border);
+    border-radius: 8px; padding: 8px 12px; font-size: 11px; color: var(--muted);
+    max-width: 360px; line-height: 1.6; }
+  .help kbd { font-family: var(--mono); background: var(--panel);
+    border: 1px solid var(--border); border-radius: 3px; padding: 1px 5px;
+    color: var(--fg); }
+
+  .approve { position: absolute; pointer-events: auto;
+    background: var(--panel); border: 1px solid var(--warn); color: var(--warn);
+    border-radius: 6px; padding: 6px 10px; font: inherit; font-size: 11px;
+    font-family: var(--mono); cursor: pointer; transform: translate(-50%, -50%);
+    box-shadow: 0 0 24px rgba(251, 191, 36, 0.25); }
+  .approve:hover { background: var(--warn); color: var(--bg); }
+
+  .tag { display: inline-block; padding: 1px 6px; border-radius: 3px;
+    background: var(--panel); border: 1px solid var(--border); font-size: 10px;
+    color: var(--muted); margin-right: 4px; }
+  .tag.high { color: var(--hot); border-color: var(--hot); }
+  .tag.medium { color: var(--warn); border-color: var(--warn); }
+  .tag.low { color: var(--muted); }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>switchboard<span class="dot">.</span> agentic payments demo</h1>
+  <div class="crumbs">
+    <a href="./index.html">← protocol explorer</a> ·
+    <a href="https://github.com/kcolbchain/switchboard">github</a>
+  </div>
+</header>
+
+<div class="layout">
+
+  <aside class="left">
+    <h2>Selected agent</h2>
+    <div id="info" class="agent-info">
+      <div class="empty">hover an agent to inspect</div>
+    </div>
+
+    <h2>Legend</h2>
+    <div class="legend">
+      <div><span class="dot" style="background: var(--agentic)"></span>agentic wallet — auto-pays</div>
+      <div><span class="dot" style="background: var(--hitl)"></span>human-in-the-loop — gates each spend</div>
+      <div><span class="dot" style="background: var(--treasury)"></span>treasury — high balance, low velocity</div>
+      <div style="margin-top:8px;color:var(--fg)">states</div>
+      <div>glowing — active, ready to transact</div>
+      <div>frosted — passive, low budget left</div>
+      <div>pulsing — paying / awaiting confirmation</div>
+      <div>locked ring — needs human approval</div>
+    </div>
+
+    <h2>How to play</h2>
+    <div class="legend">
+      <div><kbd>hover</kbd> reveal signature gradient</div>
+      <div><kbd>click</kbd> agent sends payment to its top-priority target</div>
+      <div><kbd>shift+click</kbd> open channel between two agents</div>
+      <div><kbd>space</kbd> pause / resume the world</div>
+    </div>
+  </aside>
+
+  <div class="stage">
+    <canvas id="canvas"></canvas>
+    <div class="stats">
+      <div><span class="label">tick</span><span id="tick" class="val">0</span></div>
+      <div><span class="label">jobs</span><span id="jobs" class="val ok">0</span></div>
+      <div><span class="label">budget left</span><span id="budget" class="val">100%</span></div>
+      <div><span class="label">paused</span><span id="paused" class="val">no</span></div>
+    </div>
+    <div class="help">
+      Each circle is an agent. Inner-core brightness = balance. Outer-ring color = wallet type. Hover reveals each agent's unique signature gradient — the visual stand-in for the PQ signature it would attach to a <code>PaymentOffer</code> / <code>PaymentProof</code>. Yellow rings = human-in-the-loop gate (click <em>approve</em> to release).
+    </div>
+  </div>
+
+  <aside class="right">
+    <h2>Activity log</h2>
+    <div id="log" class="log">
+      <div class="row"><span class="t">000</span><span class="m">world started, 7 agents online.</span></div>
+    </div>
+  </aside>
+
+</div>
+
+<script>
+(() => {
+  const cvs = document.getElementById("canvas");
+  const ctx = cvs.getContext("2d");
+  const infoEl = document.getElementById("info");
+  const logEl = document.getElementById("log");
+  const tickEl = document.getElementById("tick");
+  const jobsEl = document.getElementById("jobs");
+  const budgetEl = document.getElementById("budget");
+  const pausedEl = document.getElementById("paused");
+
+  let DPR = window.devicePixelRatio || 1;
+  let W = 0, H = 0;
+  let mouse = { x: -1, y: -1, down: false, shift: false };
+  let hoverId = null;
+  let paused = false;
+  let tick = 0;
+  let jobs = 0;
+  let totalSpent = 0;
+  const TOTAL_BUDGET = 200;
+
+  function resize() {
+    const rect = cvs.parentElement.getBoundingClientRect();
+    W = rect.width; H = rect.height;
+    cvs.width = W * DPR; cvs.height = H * DPR;
+    cvs.style.width = W + "px"; cvs.style.height = H + "px";
+    ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    layout();
+  }
+  window.addEventListener("resize", resize);
+
+  // ─── agent model ──────────────────────────────────────────────────────────
+  // Each agent has a "signature hue" — the visual stand-in for its PQ pubkey.
+  // No two agents share a hue; hover reveals the gradient as if showing the
+  // signing material on the wire.
+  const AGENTS = [
+    { id:"alice",   name:"Alice",   role:"researcher",     wallet:"agentic",  hue: 195, balance: 8.0, dailyCap: 12.0, priority:"medium" },
+    { id:"bob",     name:"Bob",     role:"data-broker",    wallet:"agentic",  hue: 145, balance: 5.0, dailyCap:  8.0, priority:"high"   },
+    { id:"chen",    name:"Chen",    role:"oracle",         wallet:"treasury", hue: 270, balance:50.0, dailyCap: 80.0, priority:"low"    },
+    { id:"deva",    name:"Deva",    role:"trader",         wallet:"hitl",     hue:  40, balance: 3.0, dailyCap: 20.0, priority:"high"   },
+    { id:"eli",     name:"Eli",     role:"inference-svc",  wallet:"agentic",  hue: 320, balance: 2.5, dailyCap:  6.0, priority:"medium" },
+    { id:"fina",    name:"Fina",    role:"settlement-hub", wallet:"treasury", hue: 230, balance:80.0, dailyCap: 90.0, priority:"low"    },
+    { id:"gus",     name:"Gus",     role:"market-maker",   wallet:"hitl",     hue:   8, balance: 4.5, dailyCap: 25.0, priority:"high"   },
+  ];
+
+  // Annotate at runtime so we can lay them out + animate.
+  AGENTS.forEach(a => {
+    a.spent = 0;
+    a.state = "active";              // active | passive | paying | awaitingApproval
+    a.glowPhase = Math.random() * Math.PI * 2;
+    a.radius = a.wallet === "treasury" ? 46 : 34;
+    a.pos = { x: 0, y: 0 };
+    a.target = { x: 0, y: 0 };
+    a.queue = [];                    // pending purchases (for flavor)
+  });
+
+  function layout() {
+    // Position agents in a loose ring with treasuries on the outside.
+    const cx = W / 2, cy = H / 2;
+    const N = AGENTS.length;
+    AGENTS.forEach((a, i) => {
+      const r = (Math.min(W, H) * (a.wallet === "treasury" ? 0.38 : 0.28));
+      const angle = (i / N) * Math.PI * 2 - Math.PI / 2;
+      a.pos.x = cx + Math.cos(angle) * r;
+      a.pos.y = cy + Math.sin(angle) * r;
+      a.target.x = a.pos.x; a.target.y = a.pos.y;
+    });
+  }
+
+  // ─── payment packets ──────────────────────────────────────────────────────
+  // Each packet is a moving point: PaymentOffer (payer → payee), then on
+  // arrival a PaymentProof flies back. Visually it's a comet.
+  const packets = [];
+
+  function emitPacket(fromId, toId, amount, kind /* offer | proof */) {
+    const from = AGENTS.find(a => a.id === fromId);
+    const to   = AGENTS.find(a => a.id === toId);
+    if (!from || !to) return;
+    packets.push({
+      from, to, amount, kind,
+      t: 0,
+      speed: 0.012,                  // fraction of trip per tick
+      trail: [],
+    });
+  }
+
+  function spawnApproval(packet) {
+    // For HITL payer: render an Approve button at the agent.
+    const a = packet.from;
+    a.state = "awaitingApproval";
+    const btn = document.createElement("button");
+    btn.className = "approve";
+    btn.textContent = "approve " + packet.amount.toFixed(2) + " USDC →";
+    btn.style.left = (cvs.getBoundingClientRect().left + a.pos.x) + "px";
+    btn.style.top  = (cvs.getBoundingClientRect().top  + a.pos.y - a.radius - 24) + "px";
+    document.body.appendChild(btn);
+    btn.addEventListener("click", () => {
+      a.state = "paying";
+      btn.remove();
+      log(`<span class="warn">${a.name}</span> approved → packet released`);
+      emitPacket(a.id, packet.to.id, packet.amount, "offer");
+    });
+    a._approveBtn = btn;
+    log(`<span class="warn">${a.name}</span> awaiting human approval to spend ${packet.amount.toFixed(2)} USDC`);
+  }
+
+  // ─── interactions ─────────────────────────────────────────────────────────
+  cvs.addEventListener("mousemove", e => {
+    const r = cvs.getBoundingClientRect();
+    mouse.x = e.clientX - r.left;
+    mouse.y = e.clientY - r.top;
+    hoverId = pickAgent(mouse.x, mouse.y);
+    renderInfo();
+  });
+  cvs.addEventListener("mouseleave", () => {
+    mouse.x = -1; mouse.y = -1; hoverId = null; renderInfo();
+  });
+  cvs.addEventListener("click", e => {
+    if (!hoverId) return;
+    const a = AGENTS.find(x => x.id === hoverId);
+    initiatePayment(a, e.shiftKey);
+  });
+  window.addEventListener("keydown", e => {
+    if (e.code === "Space") { paused = !paused; pausedEl.textContent = paused ? "yes" : "no"; }
+    mouse.shift = e.shiftKey;
+  });
+  window.addEventListener("keyup", e => { mouse.shift = e.shiftKey; });
+
+  function pickAgent(x, y) {
+    for (const a of AGENTS) {
+      const dx = x - a.pos.x, dy = y - a.pos.y;
+      if (dx*dx + dy*dy <= a.radius * a.radius) return a.id;
+    }
+    return null;
+  }
+
+  function initiatePayment(payer, openChannel) {
+    if (payer.state === "awaitingApproval") return;
+    // pick the target by priority + neighbor distance
+    const candidates = AGENTS
+      .filter(t => t.id !== payer.id)
+      .map(t => ({
+        t,
+        score: priorityScore(payer, t),
+        dist: Math.hypot(t.pos.x - payer.pos.x, t.pos.y - payer.pos.y),
+      }))
+      .sort((a, b) => b.score - a.score || a.dist - b.dist);
+    const payee = candidates[0]?.t;
+    if (!payee) return;
+
+    const amount = 0.25 + Math.random() * 1.25;   // 0.25–1.5 USDC
+    if (payer.balance < amount) {
+      log(`<span class="hot">${payer.name}</span> too low to spend (${payer.balance.toFixed(2)} USDC)`);
+      payer.state = "passive";
+      return;
+    }
+    if (payer.spent + amount > payer.dailyCap) {
+      log(`<span class="hot">${payer.name}</span> blocked: would exceed daily cap`);
+      return;
+    }
+
+    if (payer.wallet === "hitl") {
+      spawnApproval({ from: payer, to: payee, amount });
+    } else {
+      payer.state = "paying";
+      emitPacket(payer.id, payee.id, amount, "offer");
+      log(`${payer.name} → ${payee.name}: offer ${amount.toFixed(2)} USDC`);
+    }
+  }
+
+  function priorityScore(payer, candidate) {
+    let s = 0;
+    if (candidate.priority === "high")   s += 3;
+    if (candidate.priority === "medium") s += 1;
+    if (candidate.wallet === "treasury") s -= 1;   // don't drain treasuries
+    if (candidate.state === "passive")   s -= 2;
+    return s + Math.random() * 0.5;
+  }
+
+  // ─── tick + draw loop ─────────────────────────────────────────────────────
+  function step() {
+    if (!paused) tick++;
+    // refresh agent state classifications
+    for (const a of AGENTS) {
+      if (a.state === "awaitingApproval") continue;
+      const ratio = a.balance / a.dailyCap;
+      if (ratio < 0.15) a.state = "passive";
+      else if (a.state !== "paying") a.state = "active";
+      a.glowPhase += 0.05;
+    }
+
+    if (!paused) {
+      for (let i = packets.length - 1; i >= 0; i--) {
+        const p = packets[i];
+        p.t += p.speed;
+        p.trail.push({ x: lerp(p.from.pos.x, p.to.pos.x, p.t),
+                       y: lerp(p.from.pos.y, p.to.pos.y, p.t),
+                       age: 0 });
+        if (p.trail.length > 16) p.trail.shift();
+        p.trail.forEach(pt => pt.age++);
+        if (p.t >= 1) {
+          packets.splice(i, 1);
+          if (p.kind === "offer") {
+            // payee receives, accepts, payer balance moves on the spot, send back proof.
+            p.from.balance -= p.amount;
+            p.from.spent += p.amount;
+            p.to.balance   += p.amount;
+            totalSpent     += p.amount;
+            jobs++;
+            jobsEl.textContent = jobs;
+            const left = Math.max(0, 100 - (totalSpent / TOTAL_BUDGET) * 100);
+            budgetEl.textContent = left.toFixed(0) + "%";
+            budgetEl.classList.toggle("ok", left > 30);
+            log(`<span class="ok">${p.to.name}</span> ← ${p.from.name}: ${p.amount.toFixed(2)} USDC settled; proof returning`);
+            emitPacket(p.to.id, p.from.id, p.amount, "proof");
+          } else {
+            p.from.state = "active";   // payee is fine
+            p.to.state   = "active";   // payer back to normal
+          }
+        }
+      }
+    }
+
+    draw();
+    requestAnimationFrame(step);
+    if (tick % 30 === 0) tickEl.textContent = tick;
+  }
+
+  function lerp(a, b, t) { return a + (b - a) * t; }
+
+  // ─── drawing ──────────────────────────────────────────────────────────────
+  function draw() {
+    ctx.clearRect(0, 0, W, H);
+    drawGrid();
+    drawChannels();
+    for (const p of packets) drawPacket(p);
+    for (const a of AGENTS) drawAgent(a);
+  }
+
+  function drawGrid() {
+    ctx.save();
+    ctx.strokeStyle = "rgba(35, 39, 47, 0.6)";
+    ctx.lineWidth = 1;
+    const step = 40;
+    for (let x = 0; x < W; x += step) {
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+    }
+    for (let y = 0; y < H; y += step) {
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  function drawChannels() {
+    // Thin lines between active agents to suggest the substrate.
+    ctx.save();
+    ctx.strokeStyle = "rgba(96, 165, 250, 0.04)";
+    ctx.lineWidth = 1;
+    for (let i = 0; i < AGENTS.length; i++) {
+      for (let j = i+1; j < AGENTS.length; j++) {
+        ctx.beginPath();
+        ctx.moveTo(AGENTS[i].pos.x, AGENTS[i].pos.y);
+        ctx.lineTo(AGENTS[j].pos.x, AGENTS[j].pos.y);
+        ctx.stroke();
+      }
+    }
+    ctx.restore();
+  }
+
+  function walletColor(w) {
+    if (w === "agentic")  return "#7dd3fc";
+    if (w === "hitl")     return "#fbbf24";
+    if (w === "treasury") return "#a78bfa";
+    return "#8a93a3";
+  }
+
+  function drawAgent(a) {
+    const { x, y } = a.pos, r = a.radius;
+    const hovered = (a.id === hoverId);
+    const balanceRatio = Math.min(1, a.balance / a.dailyCap);
+
+    // outer halo when active
+    if (a.state === "active" || a.state === "paying") {
+      const pulse = 0.5 + 0.5 * Math.sin(a.glowPhase);
+      const haloR = r + 14 + (a.state === "paying" ? 8 * pulse : 4 * pulse);
+      const g = ctx.createRadialGradient(x, y, r, x, y, haloR);
+      g.addColorStop(0, "rgba(255,255,255,0)");
+      const c = hsla(a.hue, 80, 60, 0.35 * (a.state === "paying" ? 1 : 0.55));
+      g.addColorStop(1, c.replace(/[\d.]+\)$/, "0)"));
+      g.addColorStop(0.7, c);
+      ctx.fillStyle = g;
+      ctx.beginPath(); ctx.arc(x, y, haloR, 0, Math.PI*2); ctx.fill();
+    }
+
+    // signature gradient — only when hovered
+    if (hovered) {
+      const ang = (tick * 0.04) % (Math.PI * 2);
+      const sigR = r + 26;
+      // conic-ish via segmented arcs
+      for (let i = 0; i < 60; i++) {
+        const a0 = ang + (i / 60) * Math.PI * 2;
+        const a1 = ang + ((i+1) / 60) * Math.PI * 2;
+        const hue = (a.hue + i * 6) % 360;
+        ctx.beginPath();
+        ctx.arc(x, y, sigR, a0, a1);
+        ctx.strokeStyle = hsla(hue, 90, 65, 0.55);
+        ctx.lineWidth = 4;
+        ctx.stroke();
+      }
+    }
+
+    // body: frosted glass for passive, glowing core for active
+    ctx.save();
+    if (a.state === "passive") {
+      // tinted glass — low alpha fill + subtle border
+      const g = ctx.createRadialGradient(x - r*0.3, y - r*0.3, r*0.1, x, y, r);
+      g.addColorStop(0, hsla(a.hue, 40, 70, 0.22));
+      g.addColorStop(1, hsla(a.hue, 40, 30, 0.08));
+      ctx.fillStyle = g;
+      ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI*2); ctx.fill();
+      ctx.strokeStyle = "rgba(231, 233, 238, 0.12)";
+      ctx.lineWidth = 1; ctx.stroke();
+    } else {
+      // glowing core — inner brightness scaled by balance
+      const inner = ctx.createRadialGradient(x, y, 1, x, y, r);
+      inner.addColorStop(0,  hsla(a.hue, 95, 70, 0.95 * (0.35 + 0.65 * balanceRatio)));
+      inner.addColorStop(0.6, hsla(a.hue, 85, 50, 0.55 * (0.4 + 0.6 * balanceRatio)));
+      inner.addColorStop(1,  hsla(a.hue, 60, 30, 0.85));
+      ctx.fillStyle = inner;
+      ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI*2); ctx.fill();
+      // wallet-type ring
+      ctx.strokeStyle = walletColor(a.wallet);
+      ctx.lineWidth = a.wallet === "treasury" ? 2.4 : 1.6;
+      ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI*2); ctx.stroke();
+    }
+    ctx.restore();
+
+    // HITL lock indicator
+    if (a.wallet === "hitl") {
+      const lockY = y - r - 6;
+      ctx.fillStyle = "rgba(251, 191, 36, 0.9)";
+      ctx.beginPath(); ctx.arc(x, lockY, 3, 0, Math.PI*2); ctx.fill();
+    }
+
+    // awaitingApproval ring
+    if (a.state === "awaitingApproval") {
+      ctx.strokeStyle = "rgba(251, 191, 36, 0.9)";
+      ctx.lineWidth = 2;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath(); ctx.arc(x, y, r + 8, 0, Math.PI*2); ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // name label
+    ctx.fillStyle = hovered ? "rgba(231, 233, 238, 0.95)" : "rgba(231, 233, 238, 0.6)";
+    ctx.font = "11px ui-monospace, Menlo, monospace";
+    ctx.textAlign = "center";
+    ctx.fillText(a.name, x, y + r + 16);
+  }
+
+  function drawPacket(p) {
+    // trail
+    p.trail.forEach((pt, i) => {
+      const alpha = (i / p.trail.length) * 0.7;
+      const hue = p.kind === "offer" ? p.from.hue : p.to.hue;
+      ctx.fillStyle = hsla(hue, 90, 70, alpha);
+      ctx.beginPath(); ctx.arc(pt.x, pt.y, 2, 0, Math.PI*2); ctx.fill();
+    });
+    // head
+    const x = lerp(p.from.pos.x, p.to.pos.x, p.t);
+    const y = lerp(p.from.pos.y, p.to.pos.y, p.t);
+    ctx.fillStyle = p.kind === "offer" ? "#e7e9ee" : "#34d399";
+    ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI*2); ctx.fill();
+    // halo on the head
+    const g = ctx.createRadialGradient(x, y, 1, x, y, 14);
+    const hue = p.kind === "offer" ? p.from.hue : 140;
+    g.addColorStop(0, hsla(hue, 90, 70, 0.6));
+    g.addColorStop(1, hsla(hue, 90, 70, 0));
+    ctx.fillStyle = g;
+    ctx.beginPath(); ctx.arc(x, y, 14, 0, Math.PI*2); ctx.fill();
+  }
+
+  function hsla(h, s, l, a) {
+    return `hsla(${h}, ${s}%, ${l}%, ${a})`;
+  }
+
+  // ─── side-panel renders ──────────────────────────────────────────────────
+  function renderInfo() {
+    if (!hoverId) {
+      infoEl.innerHTML = `<div class="empty">hover an agent to inspect</div>`;
+      return;
+    }
+    const a = AGENTS.find(x => x.id === hoverId);
+    const pct = Math.min(100, (a.spent / a.dailyCap) * 100);
+    const over = a.spent > a.dailyCap * 0.9;
+    infoEl.innerHTML = `
+      <div class="name">${a.name}</div>
+      <div class="role">${a.role}</div>
+      <dl>
+        <dt>wallet</dt><dd>${a.wallet}</dd>
+        <dt>balance</dt><dd>${a.balance.toFixed(2)} USDC</dd>
+        <dt>daily cap</dt><dd>${a.dailyCap.toFixed(2)} USDC</dd>
+        <dt>spent today</dt><dd>${a.spent.toFixed(2)} USDC</dd>
+        <dt>priority</dt><dd><span class="tag ${a.priority}">${a.priority}</span></dd>
+        <dt>state</dt><dd>${a.state}</dd>
+        <dt>sig hue</dt><dd>h${a.hue}°</dd>
+      </dl>
+      <div class="bar ${over ? "over" : ""}"><div style="width:${pct}%"></div></div>
+    `;
+  }
+
+  function log(html) {
+    const row = document.createElement("div");
+    row.className = "row";
+    row.innerHTML = `<span class="t">${String(tick).padStart(3, "0")}</span><span class="m">${html}</span>`;
+    logEl.prepend(row);
+    while (logEl.children.length > 60) logEl.lastChild.remove();
+  }
+
+  // ─── go ───────────────────────────────────────────────────────────────────
+  resize();
+  layout();
+  requestAnimationFrame(step);
+
+  // small ambient action so the canvas isn't dead on load
+  setInterval(() => {
+    if (paused) return;
+    const eligible = AGENTS.filter(a => a.state === "active" && a.balance > 1);
+    if (!eligible.length) return;
+    const a = eligible[Math.floor(Math.random() * eligible.length)];
+    if (Math.random() < 0.4) initiatePayment(a, false);
+  }, 2200);
+})();
+</script>
+
+</body>
+</html>

--- a/web/agents-demo.html
+++ b/web/agents-demo.html
@@ -3,14 +3,14 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>switchboard — agentic payments demo</title>
-<meta name="description" content="Interactive canvas demo of agent-to-agent payments. Hover to reveal each agent's signature gradient, click to send a payment, watch human-in-the-loop gates." />
+<title>agent payments — interactive lab</title>
+<meta name="description" content="Interactive canvas lab of agent-to-agent payment patterns: HTTP-402 paywalls, on-chain escrow, streaming micropayments, AI compute auctions, human-in-the-loop, treasury rebalance, oracle pull." />
 <style>
   :root {
     --bg: #0b0d10; --panel: #13161b; --panel-2: #0f1216; --border: #23272f;
-    --fg: #e7e9ee; --muted: #8a93a3;
+    --fg: #e7e9ee; --muted: #8a93a3; --muted-2: #5a6270;
     --accent: #60a5fa; --ok: #34d399; --warn: #fbbf24; --hot: #f87171; --info: #7dd3fc;
-    --agentic: #7dd3fc; --hitl: #fbbf24; --treasury: #a78bfa;
+    --agentic: #7dd3fc; --hitl: #fbbf24; --treasury: #a78bfa; --provider: #34d399; --oracle: #f0abfc;
     --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   }
   * { box-sizing: border-box; }
@@ -20,123 +20,145 @@
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
 
-  header { padding: 14px 24px; border-bottom: 1px solid var(--border);
-    display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
-  header h1 { margin: 0; font-size: 16px; font-weight: 600; }
-  header h1 .dot { color: var(--accent); }
-  header .crumbs { color: var(--muted); font-size: 12px; }
-  header .crumbs a { color: var(--muted); }
-  header .crumbs a:hover { color: var(--fg); }
+  header { padding: 12px 24px; border-bottom: 1px solid var(--border);
+    display: flex; justify-content: space-between; align-items: center; gap: 12px;
+    flex-wrap: wrap; }
+  header h1 { margin: 0; font-size: 14px; font-weight: 500; color: var(--muted); letter-spacing: 0.02em; }
+  header h1 .name { color: var(--fg); font-weight: 600; }
+  header .crumbs { color: var(--muted-2); font-size: 11px; }
+  header .crumbs a { color: var(--muted-2); }
 
-  .layout { display: grid; grid-template-columns: 260px 1fr 280px;
-    height: calc(100vh - 50px); }
+  .scene-bar { display: flex; gap: 4px; padding: 8px 24px; border-bottom: 1px solid var(--border);
+    background: var(--panel-2); overflow-x: auto; }
+  .scene-bar button { background: transparent; color: var(--muted); border: 1px solid transparent;
+    padding: 5px 11px; border-radius: 6px; cursor: pointer;
+    font: inherit; font-size: 12px; white-space: nowrap; }
+  .scene-bar button:hover { color: var(--fg); }
+  .scene-bar button.active { background: var(--panel); color: var(--fg); border-color: var(--border); }
+  .scene-bar button .num { color: var(--muted-2); font-family: var(--mono); margin-right: 6px; }
 
-  aside { background: var(--panel-2); border-right: 1px solid var(--border);
-    padding: 16px; overflow-y: auto; }
+  .layout { display: grid; grid-template-columns: 240px 1fr 300px;
+    height: calc(100vh - 95px); }
+
+  aside { background: var(--panel-2); padding: 14px 16px; overflow-y: auto;
+    border-right: 1px solid var(--border); }
   aside.right { border-right: none; border-left: 1px solid var(--border); }
-  aside h2 { font-size: 11px; color: var(--muted); text-transform: uppercase;
-    letter-spacing: 0.08em; margin: 0 0 8px 0; }
-  aside h2:not(:first-child) { margin-top: 18px; }
+  aside h2 { font-size: 10px; color: var(--muted); text-transform: uppercase;
+    letter-spacing: 0.1em; margin: 0 0 8px 0; font-weight: 500; }
+  aside h2:not(:first-child) { margin-top: 16px; }
 
-  .legend { font-size: 12px; color: var(--muted); line-height: 1.7; }
-  .legend .dot { display: inline-block; width: 8px; height: 8px;
-    border-radius: 50%; vertical-align: 1px; margin-right: 6px; }
+  .scene-title { font-size: 15px; font-weight: 600; color: var(--fg); margin: 0 0 4px 0; }
+  .scene-desc { font-size: 12px; color: var(--muted); line-height: 1.55; }
+  .scene-desc code { font-family: var(--mono); font-size: 11px; color: var(--info);
+    background: var(--panel); padding: 1px 4px; border-radius: 3px; }
 
-  .agent-info { font-family: var(--mono); font-size: 12px; }
-  .agent-info .name { font-size: 14px; color: var(--fg); font-family: inherit;
-    margin-bottom: 4px; font-family: -apple-system, system-ui, sans-serif; font-weight: 600; }
+  .agent-info { font-family: var(--mono); font-size: 11px; }
+  .agent-info .name { font-size: 13px; color: var(--fg);
+    font-family: -apple-system, system-ui, sans-serif; font-weight: 600; margin-bottom: 2px; }
   .agent-info .role { color: var(--muted); font-family: -apple-system, system-ui, sans-serif;
-    margin-bottom: 12px; }
+    margin-bottom: 10px; font-size: 11px; }
   .agent-info dl { margin: 0; display: grid; grid-template-columns: auto 1fr;
-    gap: 4px 12px; }
-  .agent-info dt { color: var(--muted); }
+    gap: 3px 10px; }
+  .agent-info dt { color: var(--muted-2); }
   .agent-info dd { margin: 0; color: var(--fg); }
-  .agent-info .bar { height: 4px; background: var(--panel); border-radius: 2px;
+  .agent-info .bar { height: 3px; background: var(--panel); border-radius: 2px;
     overflow: hidden; margin-top: 4px; }
-  .agent-info .bar > div { height: 100%; background: var(--ok); }
+  .agent-info .bar > div { height: 100%; background: var(--ok); transition: width 0.2s; }
+  .agent-info .bar.warn > div { background: var(--warn); }
   .agent-info .bar.over > div { background: var(--hot); }
 
-  .empty { color: var(--muted); font-style: italic; font-size: 12px; }
+  .empty { color: var(--muted-2); font-style: italic; font-size: 11px; }
 
-  .log { font-family: var(--mono); font-size: 11px; line-height: 1.5; }
-  .log .row { padding: 4px 0; border-bottom: 1px dashed var(--border);
-    display: flex; gap: 8px; }
-  .log .t { color: var(--muted); flex: 0 0 38px; }
+  .legend { font-size: 11px; color: var(--muted); line-height: 1.8; }
+  .legend .dot { display: inline-block; width: 7px; height: 7px;
+    border-radius: 50%; vertical-align: 1px; margin-right: 6px; }
+  .legend .row-key { color: var(--fg); }
+
+  .log { font-family: var(--mono); font-size: 10px; line-height: 1.5; }
+  .log .row { padding: 3px 0; border-bottom: 1px dashed var(--border);
+    display: flex; gap: 6px; }
+  .log .t { color: var(--muted-2); flex: 0 0 32px; }
   .log .m { color: var(--fg); flex: 1; word-break: break-word; }
   .log .ok { color: var(--ok); }
   .log .warn { color: var(--warn); }
   .log .hot { color: var(--hot); }
+  .log .info { color: var(--info); }
+  .log .seg { color: var(--muted); }
 
-  .stage { position: relative; }
+  .stage { position: relative; overflow: hidden; background: var(--bg); }
   canvas { display: block; width: 100%; height: 100%; cursor: crosshair; }
 
-  .stats { position: absolute; top: 12px; left: 12px;
+  .stats { position: absolute; top: 10px; left: 12px;
     background: rgba(13, 16, 21, 0.85); border: 1px solid var(--border);
-    border-radius: 8px; padding: 8px 12px; font-family: var(--mono); font-size: 11px;
-    display: flex; gap: 16px; }
-  .stats .label { color: var(--muted); margin-right: 4px; }
+    border-radius: 6px; padding: 6px 10px; font-family: var(--mono); font-size: 10px;
+    display: flex; gap: 14px; }
+  .stats .label { color: var(--muted-2); margin-right: 4px; }
   .stats .val { color: var(--fg); }
   .stats .val.ok { color: var(--ok); }
+  .stats .val.warn { color: var(--warn); }
 
-  .help { position: absolute; bottom: 12px; left: 12px;
-    background: rgba(13, 16, 21, 0.85); border: 1px solid var(--border);
-    border-radius: 8px; padding: 8px 12px; font-size: 11px; color: var(--muted);
-    max-width: 360px; line-height: 1.6; }
-  .help kbd { font-family: var(--mono); background: var(--panel);
-    border: 1px solid var(--border); border-radius: 3px; padding: 1px 5px;
-    color: var(--fg); }
+  .caption { position: absolute; bottom: 10px; left: 12px; right: 12px;
+    background: rgba(13, 16, 21, 0.86); border: 1px solid var(--border);
+    border-radius: 6px; padding: 10px 14px; font-size: 11px; color: var(--muted);
+    line-height: 1.55; max-width: 720px; margin: 0 auto; }
+  .caption .step { color: var(--info); font-family: var(--mono); font-size: 10px;
+    margin-right: 8px; }
+  .caption code { font-family: var(--mono); color: var(--fg);
+    background: rgba(96, 165, 250, 0.08); padding: 1px 4px; border-radius: 3px; }
+  .caption .pill { display: inline-block; padding: 1px 6px; border-radius: 3px;
+    background: var(--panel); border: 1px solid var(--border); font-size: 10px;
+    color: var(--muted); margin: 0 3px; font-family: var(--mono); }
 
   .approve { position: absolute; pointer-events: auto;
     background: var(--panel); border: 1px solid var(--warn); color: var(--warn);
-    border-radius: 6px; padding: 6px 10px; font: inherit; font-size: 11px;
+    border-radius: 6px; padding: 5px 10px; font: inherit; font-size: 10px;
     font-family: var(--mono); cursor: pointer; transform: translate(-50%, -50%);
     box-shadow: 0 0 24px rgba(251, 191, 36, 0.25); }
   .approve:hover { background: var(--warn); color: var(--bg); }
 
   .tag { display: inline-block; padding: 1px 6px; border-radius: 3px;
     background: var(--panel); border: 1px solid var(--border); font-size: 10px;
-    color: var(--muted); margin-right: 4px; }
+    color: var(--muted); margin-right: 4px; font-family: var(--mono); }
   .tag.high { color: var(--hot); border-color: var(--hot); }
   .tag.medium { color: var(--warn); border-color: var(--warn); }
   .tag.low { color: var(--muted); }
+
+  footer { position: fixed; bottom: 4px; right: 8px; font-size: 10px;
+    color: var(--muted-2); font-family: var(--mono); }
+  footer a { color: var(--muted-2); }
 </style>
 </head>
 <body>
 
 <header>
-  <h1>switchboard<span class="dot">.</span> agentic payments demo</h1>
+  <h1><span class="name">switchboard</span> · agent payments lab</h1>
   <div class="crumbs">
-    <a href="./index.html">← protocol explorer</a> ·
-    <a href="https://github.com/kcolbchain/switchboard">github</a>
+    <a href="./index.html">protocol explorer</a> ·
+    <span>vanilla canvas, no build</span>
   </div>
 </header>
+
+<div class="scene-bar" id="sceneBar"></div>
 
 <div class="layout">
 
   <aside class="left">
-    <h2>Selected agent</h2>
+    <h2 id="sceneLabel">Scene</h2>
+    <div class="scene-title" id="sceneTitle">—</div>
+    <div class="scene-desc" id="sceneDesc"></div>
+
+    <h2>Inspector</h2>
     <div id="info" class="agent-info">
       <div class="empty">hover an agent to inspect</div>
     </div>
 
     <h2>Legend</h2>
     <div class="legend">
-      <div><span class="dot" style="background: var(--agentic)"></span>agentic wallet — auto-pays</div>
-      <div><span class="dot" style="background: var(--hitl)"></span>human-in-the-loop — gates each spend</div>
-      <div><span class="dot" style="background: var(--treasury)"></span>treasury — high balance, low velocity</div>
-      <div style="margin-top:8px;color:var(--fg)">states</div>
-      <div>glowing — active, ready to transact</div>
-      <div>frosted — passive, low budget left</div>
-      <div>pulsing — paying / awaiting confirmation</div>
-      <div>locked ring — needs human approval</div>
-    </div>
-
-    <h2>How to play</h2>
-    <div class="legend">
-      <div><kbd>hover</kbd> reveal signature gradient</div>
-      <div><kbd>click</kbd> agent sends payment to its top-priority target</div>
-      <div><kbd>shift+click</kbd> open channel between two agents</div>
-      <div><kbd>space</kbd> pause / resume the world</div>
+      <div><span class="dot" style="background: var(--agentic)"></span><span class="row-key">agentic</span> — auto-pays</div>
+      <div><span class="dot" style="background: var(--hitl)"></span><span class="row-key">human-in-loop</span> — gates spend</div>
+      <div><span class="dot" style="background: var(--treasury)"></span><span class="row-key">treasury</span> — high balance, low velocity</div>
+      <div><span class="dot" style="background: var(--provider)"></span><span class="row-key">provider</span> — sells work</div>
+      <div><span class="dot" style="background: var(--oracle)"></span><span class="row-key">oracle</span> — sells data</div>
     </div>
   </aside>
 
@@ -144,44 +166,45 @@
     <canvas id="canvas"></canvas>
     <div class="stats">
       <div><span class="label">tick</span><span id="tick" class="val">0</span></div>
+      <div><span class="label">scene-time</span><span id="sceneTime" class="val">0s</span></div>
       <div><span class="label">jobs</span><span id="jobs" class="val ok">0</span></div>
-      <div><span class="label">budget left</span><span id="budget" class="val">100%</span></div>
       <div><span class="label">paused</span><span id="paused" class="val">no</span></div>
     </div>
-    <div class="help">
-      Each circle is an agent. Inner-core brightness = balance. Outer-ring color = wallet type. Hover reveals each agent's unique signature gradient — the visual stand-in for the PQ signature it would attach to a <code>PaymentOffer</code> / <code>PaymentProof</code>. Yellow rings = human-in-the-loop gate (click <em>approve</em> to release).
+    <div class="caption" id="caption">
+      <span class="step">—</span> Pick a scene above to begin.
     </div>
   </div>
 
   <aside class="right">
     <h2>Activity log</h2>
-    <div id="log" class="log">
-      <div class="row"><span class="t">000</span><span class="m">world started, 7 agents online.</span></div>
-    </div>
+    <div id="log" class="log"></div>
   </aside>
 
 </div>
 
+<footer><a href="https://github.com/kcolbchain/switchboard">source</a></footer>
+
 <script>
 (() => {
+  // ─── canvas + state ───────────────────────────────────────────────────────
   const cvs = document.getElementById("canvas");
   const ctx = cvs.getContext("2d");
   const infoEl = document.getElementById("info");
   const logEl = document.getElementById("log");
   const tickEl = document.getElementById("tick");
   const jobsEl = document.getElementById("jobs");
-  const budgetEl = document.getElementById("budget");
+  const sceneTimeEl = document.getElementById("sceneTime");
   const pausedEl = document.getElementById("paused");
+  const captionEl = document.getElementById("caption");
 
   let DPR = window.devicePixelRatio || 1;
   let W = 0, H = 0;
-  let mouse = { x: -1, y: -1, down: false, shift: false };
+  let mouse = { x: -1, y: -1, shift: false };
   let hoverId = null;
   let paused = false;
   let tick = 0;
+  let sceneTick = 0;
   let jobs = 0;
-  let totalSpent = 0;
-  const TOTAL_BUDGET = 200;
 
   function resize() {
     const rect = cvs.parentElement.getBoundingClientRect();
@@ -189,86 +212,67 @@
     cvs.width = W * DPR; cvs.height = H * DPR;
     cvs.style.width = W + "px"; cvs.style.height = H + "px";
     ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
-    layout();
+    if (currentScene) currentScene.layout();
   }
   window.addEventListener("resize", resize);
 
-  // ─── agent model ──────────────────────────────────────────────────────────
-  // Each agent has a "signature hue" — the visual stand-in for its PQ pubkey.
-  // No two agents share a hue; hover reveals the gradient as if showing the
-  // signing material on the wire.
-  const AGENTS = [
-    { id:"alice",   name:"Alice",   role:"researcher",     wallet:"agentic",  hue: 195, balance: 8.0, dailyCap: 12.0, priority:"medium" },
-    { id:"bob",     name:"Bob",     role:"data-broker",    wallet:"agentic",  hue: 145, balance: 5.0, dailyCap:  8.0, priority:"high"   },
-    { id:"chen",    name:"Chen",    role:"oracle",         wallet:"treasury", hue: 270, balance:50.0, dailyCap: 80.0, priority:"low"    },
-    { id:"deva",    name:"Deva",    role:"trader",         wallet:"hitl",     hue:  40, balance: 3.0, dailyCap: 20.0, priority:"high"   },
-    { id:"eli",     name:"Eli",     role:"inference-svc",  wallet:"agentic",  hue: 320, balance: 2.5, dailyCap:  6.0, priority:"medium" },
-    { id:"fina",    name:"Fina",    role:"settlement-hub", wallet:"treasury", hue: 230, balance:80.0, dailyCap: 90.0, priority:"low"    },
-    { id:"gus",     name:"Gus",     role:"market-maker",   wallet:"hitl",     hue:   8, balance: 4.5, dailyCap: 25.0, priority:"high"   },
-  ];
-
-  // Annotate at runtime so we can lay them out + animate.
-  AGENTS.forEach(a => {
-    a.spent = 0;
-    a.state = "active";              // active | passive | paying | awaitingApproval
-    a.glowPhase = Math.random() * Math.PI * 2;
-    a.radius = a.wallet === "treasury" ? 46 : 34;
-    a.pos = { x: 0, y: 0 };
-    a.target = { x: 0, y: 0 };
-    a.queue = [];                    // pending purchases (for flavor)
-  });
-
-  function layout() {
-    // Position agents in a loose ring with treasuries on the outside.
-    const cx = W / 2, cy = H / 2;
-    const N = AGENTS.length;
-    AGENTS.forEach((a, i) => {
-      const r = (Math.min(W, H) * (a.wallet === "treasury" ? 0.38 : 0.28));
-      const angle = (i / N) * Math.PI * 2 - Math.PI / 2;
-      a.pos.x = cx + Math.cos(angle) * r;
-      a.pos.y = cy + Math.sin(angle) * r;
-      a.target.x = a.pos.x; a.target.y = a.pos.y;
-    });
+  // ─── agent registry ───────────────────────────────────────────────────────
+  // Each agent has a unique signature hue — the visual stand-in for its
+  // PQ public key. Hover reveals the conic gradient.
+  function makeAgent(o) {
+    return Object.assign({
+      id: "", name: "", role: "",
+      wallet: "agentic",      // agentic | hitl | treasury | provider | oracle
+      hue: 0,
+      balance: 5.0, dailyCap: 10.0, spent: 0,
+      priority: "medium",
+      state: "active",         // active | passive | paying | awaitingApproval | listening
+      radius: 32,
+      glowPhase: Math.random() * Math.PI * 2,
+      pos: { x: 0, y: 0 },
+      pinned: false,           // contracts/escrow rendered specially
+      shape: "circle",         // circle | hex (for contract / escrow)
+      meta: {},
+      _approveBtn: null,
+    }, o);
   }
 
-  // ─── payment packets ──────────────────────────────────────────────────────
-  // Each packet is a moving point: PaymentOffer (payer → payee), then on
-  // arrival a PaymentProof flies back. Visually it's a comet.
+  const A = {
+    alice:  makeAgent({ id: "alice",   name: "Alice",   role: "researcher",        wallet: "agentic",  hue: 195, balance: 8.0,  dailyCap: 12 }),
+    bob:    makeAgent({ id: "bob",     name: "Bob",     role: "data buyer",        wallet: "agentic",  hue: 145, balance: 6.0,  dailyCap: 10 }),
+    chen:   makeAgent({ id: "chen",    name: "Chen",    role: "price oracle",      wallet: "oracle",   hue: 295, balance: 30,   dailyCap: 80, radius: 38 }),
+    deva:   makeAgent({ id: "deva",    name: "Deva",    role: "trader",            wallet: "hitl",     hue:  40, balance: 4.0,  dailyCap: 25 }),
+    eli:    makeAgent({ id: "eli",     name: "Eli",     role: "inference service", wallet: "provider", hue: 152, balance: 1.0,  dailyCap: 50, radius: 36 }),
+    fina:   makeAgent({ id: "fina",    name: "Fina",    role: "treasury",          wallet: "treasury", hue: 250, balance: 80,   dailyCap: 90, radius: 44 }),
+    gus:    makeAgent({ id: "gus",     name: "Gus",     role: "image-gen service", wallet: "provider", hue:   8, balance: 0.5,  dailyCap: 40, radius: 36 }),
+    hana:   makeAgent({ id: "hana",    name: "Hana",    role: "embed service",     wallet: "provider", hue: 330, balance: 0.8,  dailyCap: 40, radius: 36 }),
+    iris:   makeAgent({ id: "iris",    name: "Iris",    role: "buyer",             wallet: "agentic",  hue: 180, balance: 6,    dailyCap: 12 }),
+    juno:   makeAgent({ id: "juno",    name: "Juno",    role: "buyer",             wallet: "agentic",  hue:  90, balance: 5,    dailyCap: 10 }),
+    escrow: makeAgent({ id: "escrow",  name: "Escrow",  role: "AgentEscrow.sol",   wallet: "contract", hue: 220, balance: 0, dailyCap: 999, radius: 30, shape: "hex" }),
+  };
+  const ALL = Object.values(A);
+
+  // ─── packets ──────────────────────────────────────────────────────────────
+  // Visual abstraction over PaymentOffer / PaymentProof / generic messages.
   const packets = [];
-
-  function emitPacket(fromId, toId, amount, kind /* offer | proof */) {
-    const from = AGENTS.find(a => a.id === fromId);
-    const to   = AGENTS.find(a => a.id === toId);
-    if (!from || !to) return;
-    packets.push({
-      from, to, amount, kind,
+  function emit(fromId, toId, opts = {}) {
+    const from = A[fromId], to = A[toId];
+    if (!from || !to) return null;
+    const p = {
+      from, to,
+      amount: opts.amount ?? 0,
+      kind: opts.kind ?? "offer",   // offer | proof | request | bid | refund | data | stream
+      label: opts.label ?? "",
+      speed: opts.speed ?? 0.014,
       t: 0,
-      speed: 0.012,                  // fraction of trip per tick
       trail: [],
-    });
+      onArrive: opts.onArrive || null,
+    };
+    packets.push(p);
+    return p;
   }
 
-  function spawnApproval(packet) {
-    // For HITL payer: render an Approve button at the agent.
-    const a = packet.from;
-    a.state = "awaitingApproval";
-    const btn = document.createElement("button");
-    btn.className = "approve";
-    btn.textContent = "approve " + packet.amount.toFixed(2) + " USDC →";
-    btn.style.left = (cvs.getBoundingClientRect().left + a.pos.x) + "px";
-    btn.style.top  = (cvs.getBoundingClientRect().top  + a.pos.y - a.radius - 24) + "px";
-    document.body.appendChild(btn);
-    btn.addEventListener("click", () => {
-      a.state = "paying";
-      btn.remove();
-      log(`<span class="warn">${a.name}</span> approved → packet released`);
-      emitPacket(a.id, packet.to.id, packet.amount, "offer");
-    });
-    a._approveBtn = btn;
-    log(`<span class="warn">${a.name}</span> awaiting human approval to spend ${packet.amount.toFixed(2)} USDC`);
-  }
-
-  // ─── interactions ─────────────────────────────────────────────────────────
+  // ─── interaction ──────────────────────────────────────────────────────────
   cvs.addEventListener("mousemove", e => {
     const r = cvs.getBoundingClientRect();
     mouse.x = e.clientX - r.left;
@@ -276,324 +280,831 @@
     hoverId = pickAgent(mouse.x, mouse.y);
     renderInfo();
   });
-  cvs.addEventListener("mouseleave", () => {
-    mouse.x = -1; mouse.y = -1; hoverId = null; renderInfo();
-  });
-  cvs.addEventListener("click", e => {
-    if (!hoverId) return;
-    const a = AGENTS.find(x => x.id === hoverId);
-    initiatePayment(a, e.shiftKey);
+  cvs.addEventListener("mouseleave", () => { hoverId = null; renderInfo(); });
+  cvs.addEventListener("click", () => {
+    if (!hoverId || !currentScene.onAgentClick) return;
+    currentScene.onAgentClick(A[hoverId]);
   });
   window.addEventListener("keydown", e => {
-    if (e.code === "Space") { paused = !paused; pausedEl.textContent = paused ? "yes" : "no"; }
-    mouse.shift = e.shiftKey;
+    if (e.code === "Space") { paused = !paused; pausedEl.textContent = paused ? "yes" : "no"; e.preventDefault(); }
+    if (e.key === "r" && currentScene) selectScene(currentScene.id, true);
   });
-  window.addEventListener("keyup", e => { mouse.shift = e.shiftKey; });
 
   function pickAgent(x, y) {
-    for (const a of AGENTS) {
+    for (const a of ALL) {
+      if (!a._visible) continue;
       const dx = x - a.pos.x, dy = y - a.pos.y;
-      if (dx*dx + dy*dy <= a.radius * a.radius) return a.id;
+      if (dx*dx + dy*dy <= (a.radius + 6) * (a.radius + 6)) return a.id;
     }
     return null;
   }
 
-  function initiatePayment(payer, openChannel) {
-    if (payer.state === "awaitingApproval") return;
-    // pick the target by priority + neighbor distance
-    const candidates = AGENTS
-      .filter(t => t.id !== payer.id)
-      .map(t => ({
-        t,
-        score: priorityScore(payer, t),
-        dist: Math.hypot(t.pos.x - payer.pos.x, t.pos.y - payer.pos.y),
-      }))
-      .sort((a, b) => b.score - a.score || a.dist - b.dist);
-    const payee = candidates[0]?.t;
-    if (!payee) return;
-
-    const amount = 0.25 + Math.random() * 1.25;   // 0.25–1.5 USDC
-    if (payer.balance < amount) {
-      log(`<span class="hot">${payer.name}</span> too low to spend (${payer.balance.toFixed(2)} USDC)`);
-      payer.state = "passive";
-      return;
-    }
-    if (payer.spent + amount > payer.dailyCap) {
-      log(`<span class="hot">${payer.name}</span> blocked: would exceed daily cap`);
-      return;
-    }
-
-    if (payer.wallet === "hitl") {
-      spawnApproval({ from: payer, to: payee, amount });
-    } else {
-      payer.state = "paying";
-      emitPacket(payer.id, payee.id, amount, "offer");
-      log(`${payer.name} → ${payee.name}: offer ${amount.toFixed(2)} USDC`);
-    }
-  }
-
-  function priorityScore(payer, candidate) {
-    let s = 0;
-    if (candidate.priority === "high")   s += 3;
-    if (candidate.priority === "medium") s += 1;
-    if (candidate.wallet === "treasury") s -= 1;   // don't drain treasuries
-    if (candidate.state === "passive")   s -= 2;
-    return s + Math.random() * 0.5;
-  }
-
-  // ─── tick + draw loop ─────────────────────────────────────────────────────
-  function step() {
-    if (!paused) tick++;
-    // refresh agent state classifications
-    for (const a of AGENTS) {
-      if (a.state === "awaitingApproval") continue;
-      const ratio = a.balance / a.dailyCap;
-      if (ratio < 0.15) a.state = "passive";
-      else if (a.state !== "paying") a.state = "active";
-      a.glowPhase += 0.05;
-    }
-
-    if (!paused) {
-      for (let i = packets.length - 1; i >= 0; i--) {
-        const p = packets[i];
-        p.t += p.speed;
-        p.trail.push({ x: lerp(p.from.pos.x, p.to.pos.x, p.t),
-                       y: lerp(p.from.pos.y, p.to.pos.y, p.t),
-                       age: 0 });
-        if (p.trail.length > 16) p.trail.shift();
-        p.trail.forEach(pt => pt.age++);
-        if (p.t >= 1) {
-          packets.splice(i, 1);
-          if (p.kind === "offer") {
-            // payee receives, accepts, payer balance moves on the spot, send back proof.
-            p.from.balance -= p.amount;
-            p.from.spent += p.amount;
-            p.to.balance   += p.amount;
-            totalSpent     += p.amount;
-            jobs++;
-            jobsEl.textContent = jobs;
-            const left = Math.max(0, 100 - (totalSpent / TOTAL_BUDGET) * 100);
-            budgetEl.textContent = left.toFixed(0) + "%";
-            budgetEl.classList.toggle("ok", left > 30);
-            log(`<span class="ok">${p.to.name}</span> ← ${p.from.name}: ${p.amount.toFixed(2)} USDC settled; proof returning`);
-            emitPacket(p.to.id, p.from.id, p.amount, "proof");
-          } else {
-            p.from.state = "active";   // payee is fine
-            p.to.state   = "active";   // payer back to normal
-          }
-        }
-      }
-    }
-
-    draw();
-    requestAnimationFrame(step);
-    if (tick % 30 === 0) tickEl.textContent = tick;
-  }
-
-  function lerp(a, b, t) { return a + (b - a) * t; }
-
   // ─── drawing ──────────────────────────────────────────────────────────────
+  function lerp(a, b, t) { return a + (b - a) * t; }
+  function hsla(h, s, l, a) { return `hsla(${h}, ${s}%, ${l}%, ${a})`; }
+
+  function walletColor(w) {
+    switch (w) {
+      case "agentic":  return "#7dd3fc";
+      case "hitl":     return "#fbbf24";
+      case "treasury": return "#a78bfa";
+      case "provider": return "#34d399";
+      case "oracle":   return "#f0abfc";
+      case "contract": return "#60a5fa";
+      default:         return "#8a93a3";
+    }
+  }
+
   function draw() {
     ctx.clearRect(0, 0, W, H);
     drawGrid();
-    drawChannels();
+    if (currentScene.drawUnderlay) currentScene.drawUnderlay(ctx, W, H);
+    if (currentScene.drawChannels) currentScene.drawChannels(ctx);
+    else drawDefaultChannels(ctx);
     for (const p of packets) drawPacket(p);
-    for (const a of AGENTS) drawAgent(a);
+    for (const a of ALL) if (a._visible) drawAgent(a);
+    if (currentScene.drawOverlay) currentScene.drawOverlay(ctx, W, H);
   }
 
   function drawGrid() {
     ctx.save();
-    ctx.strokeStyle = "rgba(35, 39, 47, 0.6)";
+    ctx.strokeStyle = "rgba(35, 39, 47, 0.4)";
     ctx.lineWidth = 1;
     const step = 40;
-    for (let x = 0; x < W; x += step) {
-      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
-    }
-    for (let y = 0; y < H; y += step) {
-      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
-    }
+    for (let x = 0; x < W; x += step) { ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke(); }
+    for (let y = 0; y < H; y += step) { ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke(); }
     ctx.restore();
   }
 
-  function drawChannels() {
-    // Thin lines between active agents to suggest the substrate.
+  function drawDefaultChannels(ctx) {
     ctx.save();
     ctx.strokeStyle = "rgba(96, 165, 250, 0.04)";
     ctx.lineWidth = 1;
-    for (let i = 0; i < AGENTS.length; i++) {
-      for (let j = i+1; j < AGENTS.length; j++) {
+    const v = ALL.filter(a => a._visible);
+    for (let i = 0; i < v.length; i++)
+      for (let j = i+1; j < v.length; j++) {
         ctx.beginPath();
-        ctx.moveTo(AGENTS[i].pos.x, AGENTS[i].pos.y);
-        ctx.lineTo(AGENTS[j].pos.x, AGENTS[j].pos.y);
+        ctx.moveTo(v[i].pos.x, v[i].pos.y);
+        ctx.lineTo(v[j].pos.x, v[j].pos.y);
         ctx.stroke();
       }
-    }
     ctx.restore();
-  }
-
-  function walletColor(w) {
-    if (w === "agentic")  return "#7dd3fc";
-    if (w === "hitl")     return "#fbbf24";
-    if (w === "treasury") return "#a78bfa";
-    return "#8a93a3";
   }
 
   function drawAgent(a) {
     const { x, y } = a.pos, r = a.radius;
     const hovered = (a.id === hoverId);
-    const balanceRatio = Math.min(1, a.balance / a.dailyCap);
+    const balanceRatio = Math.min(1, a.balance / Math.max(1, a.dailyCap));
 
-    // outer halo when active
-    if (a.state === "active" || a.state === "paying") {
+    // halo
+    if (a.state === "active" || a.state === "paying" || a.state === "listening") {
       const pulse = 0.5 + 0.5 * Math.sin(a.glowPhase);
       const haloR = r + 14 + (a.state === "paying" ? 8 * pulse : 4 * pulse);
       const g = ctx.createRadialGradient(x, y, r, x, y, haloR);
       g.addColorStop(0, "rgba(255,255,255,0)");
-      const c = hsla(a.hue, 80, 60, 0.35 * (a.state === "paying" ? 1 : 0.55));
-      g.addColorStop(1, c.replace(/[\d.]+\)$/, "0)"));
+      const c = hsla(a.hue, 80, 60, 0.32 * (a.state === "paying" ? 1 : 0.55));
       g.addColorStop(0.7, c);
+      g.addColorStop(1, c.replace(/[\d.]+\)$/, "0)"));
       ctx.fillStyle = g;
       ctx.beginPath(); ctx.arc(x, y, haloR, 0, Math.PI*2); ctx.fill();
     }
 
-    // signature gradient — only when hovered
+    // hover: signature gradient
     if (hovered) {
       const ang = (tick * 0.04) % (Math.PI * 2);
       const sigR = r + 26;
-      // conic-ish via segmented arcs
       for (let i = 0; i < 60; i++) {
         const a0 = ang + (i / 60) * Math.PI * 2;
         const a1 = ang + ((i+1) / 60) * Math.PI * 2;
         const hue = (a.hue + i * 6) % 360;
-        ctx.beginPath();
-        ctx.arc(x, y, sigR, a0, a1);
+        ctx.beginPath(); ctx.arc(x, y, sigR, a0, a1);
         ctx.strokeStyle = hsla(hue, 90, 65, 0.55);
-        ctx.lineWidth = 4;
-        ctx.stroke();
+        ctx.lineWidth = 4; ctx.stroke();
       }
     }
 
-    // body: frosted glass for passive, glowing core for active
+    // body
+    if (a.shape === "hex") drawHexBody(a, balanceRatio);
+    else drawCircleBody(a, balanceRatio);
+
+    // HITL lock dot
+    if (a.wallet === "hitl") {
+      ctx.fillStyle = "rgba(251, 191, 36, 0.9)";
+      ctx.beginPath(); ctx.arc(x, y - r - 6, 3, 0, Math.PI*2); ctx.fill();
+    }
+
+    // awaitingApproval ring
+    if (a.state === "awaitingApproval") {
+      ctx.strokeStyle = "rgba(251, 191, 36, 0.9)";
+      ctx.lineWidth = 2; ctx.setLineDash([4, 4]);
+      ctx.beginPath(); ctx.arc(x, y, r + 8, 0, Math.PI*2); ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // listening (oracle / marketplace)
+    if (a.state === "listening") {
+      ctx.strokeStyle = hsla(a.hue, 85, 65, 0.55);
+      ctx.lineWidth = 1.5; ctx.setLineDash([2, 6]);
+      ctx.beginPath(); ctx.arc(x, y, r + 14, 0, Math.PI*2); ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // labels
+    ctx.fillStyle = hovered ? "rgba(231, 233, 238, 0.95)" : "rgba(231, 233, 238, 0.62)";
+    ctx.font = "11px ui-monospace, Menlo, monospace";
+    ctx.textAlign = "center";
+    ctx.fillText(a.name, x, y + r + 16);
+    if (a.role && hovered) {
+      ctx.fillStyle = "rgba(138, 147, 163, 0.85)";
+      ctx.font = "10px ui-monospace, Menlo, monospace";
+      ctx.fillText(a.role, x, y + r + 30);
+    }
+  }
+
+  function drawCircleBody(a, balanceRatio) {
+    const { x, y } = a.pos, r = a.radius;
     ctx.save();
     if (a.state === "passive") {
-      // tinted glass — low alpha fill + subtle border
       const g = ctx.createRadialGradient(x - r*0.3, y - r*0.3, r*0.1, x, y, r);
       g.addColorStop(0, hsla(a.hue, 40, 70, 0.22));
       g.addColorStop(1, hsla(a.hue, 40, 30, 0.08));
       ctx.fillStyle = g;
       ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI*2); ctx.fill();
-      ctx.strokeStyle = "rgba(231, 233, 238, 0.12)";
-      ctx.lineWidth = 1; ctx.stroke();
+      ctx.strokeStyle = "rgba(231, 233, 238, 0.12)"; ctx.lineWidth = 1; ctx.stroke();
     } else {
-      // glowing core — inner brightness scaled by balance
       const inner = ctx.createRadialGradient(x, y, 1, x, y, r);
       inner.addColorStop(0,  hsla(a.hue, 95, 70, 0.95 * (0.35 + 0.65 * balanceRatio)));
       inner.addColorStop(0.6, hsla(a.hue, 85, 50, 0.55 * (0.4 + 0.6 * balanceRatio)));
       inner.addColorStop(1,  hsla(a.hue, 60, 30, 0.85));
       ctx.fillStyle = inner;
       ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI*2); ctx.fill();
-      // wallet-type ring
       ctx.strokeStyle = walletColor(a.wallet);
       ctx.lineWidth = a.wallet === "treasury" ? 2.4 : 1.6;
       ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI*2); ctx.stroke();
     }
     ctx.restore();
+  }
 
-    // HITL lock indicator
-    if (a.wallet === "hitl") {
-      const lockY = y - r - 6;
-      ctx.fillStyle = "rgba(251, 191, 36, 0.9)";
-      ctx.beginPath(); ctx.arc(x, lockY, 3, 0, Math.PI*2); ctx.fill();
+  function drawHexBody(a, balanceRatio) {
+    const { x, y } = a.pos, r = a.radius;
+    ctx.save();
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const ang = -Math.PI/2 + i * Math.PI / 3;
+      const px = x + Math.cos(ang) * r;
+      const py = y + Math.sin(ang) * r;
+      if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
     }
-
-    // awaitingApproval ring
-    if (a.state === "awaitingApproval") {
-      ctx.strokeStyle = "rgba(251, 191, 36, 0.9)";
-      ctx.lineWidth = 2;
-      ctx.setLineDash([4, 4]);
-      ctx.beginPath(); ctx.arc(x, y, r + 8, 0, Math.PI*2); ctx.stroke();
-      ctx.setLineDash([]);
-    }
-
-    // name label
-    ctx.fillStyle = hovered ? "rgba(231, 233, 238, 0.95)" : "rgba(231, 233, 238, 0.6)";
-    ctx.font = "11px ui-monospace, Menlo, monospace";
-    ctx.textAlign = "center";
-    ctx.fillText(a.name, x, y + r + 16);
+    ctx.closePath();
+    const inner = ctx.createRadialGradient(x, y, 1, x, y, r);
+    inner.addColorStop(0,  hsla(a.hue, 50, 50, 0.45));
+    inner.addColorStop(1,  hsla(a.hue, 30, 25, 0.85));
+    ctx.fillStyle = inner; ctx.fill();
+    ctx.strokeStyle = walletColor(a.wallet); ctx.lineWidth = 1.6; ctx.stroke();
+    // little lock icon
+    ctx.strokeStyle = hsla(a.hue, 60, 80, 0.7);
+    ctx.lineWidth = 1.4;
+    ctx.beginPath();
+    ctx.rect(x - 5, y - 2, 10, 8);
+    ctx.moveTo(x - 3, y - 2); ctx.lineTo(x - 3, y - 5);
+    ctx.arc(x, y - 5, 3, Math.PI, 0);
+    ctx.lineTo(x + 3, y - 2);
+    ctx.stroke();
+    ctx.restore();
   }
 
   function drawPacket(p) {
+    const x = lerp(p.from.pos.x, p.to.pos.x, p.t);
+    const y = lerp(p.from.pos.y, p.to.pos.y, p.t);
+    p.trail.push({ x, y });
+    if (p.trail.length > 18) p.trail.shift();
+
     // trail
     p.trail.forEach((pt, i) => {
-      const alpha = (i / p.trail.length) * 0.7;
-      const hue = p.kind === "offer" ? p.from.hue : p.to.hue;
+      const alpha = (i / p.trail.length) * 0.65;
+      const hue = packetHue(p);
       ctx.fillStyle = hsla(hue, 90, 70, alpha);
       ctx.beginPath(); ctx.arc(pt.x, pt.y, 2, 0, Math.PI*2); ctx.fill();
     });
     // head
-    const x = lerp(p.from.pos.x, p.to.pos.x, p.t);
-    const y = lerp(p.from.pos.y, p.to.pos.y, p.t);
-    ctx.fillStyle = p.kind === "offer" ? "#e7e9ee" : "#34d399";
-    ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI*2); ctx.fill();
-    // halo on the head
+    ctx.fillStyle = packetHeadColor(p);
+    ctx.beginPath(); ctx.arc(x, y, 3.5, 0, Math.PI*2); ctx.fill();
+    // halo
     const g = ctx.createRadialGradient(x, y, 1, x, y, 14);
-    const hue = p.kind === "offer" ? p.from.hue : 140;
-    g.addColorStop(0, hsla(hue, 90, 70, 0.6));
-    g.addColorStop(1, hsla(hue, 90, 70, 0));
+    g.addColorStop(0, hsla(packetHue(p), 90, 70, 0.6));
+    g.addColorStop(1, hsla(packetHue(p), 90, 70, 0));
     ctx.fillStyle = g;
     ctx.beginPath(); ctx.arc(x, y, 14, 0, Math.PI*2); ctx.fill();
+    // label
+    if (p.label) {
+      ctx.fillStyle = "rgba(231, 233, 238, 0.7)";
+      ctx.font = "10px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(p.label, x, y - 10);
+    }
   }
 
-  function hsla(h, s, l, a) {
-    return `hsla(${h}, ${s}%, ${l}%, ${a})`;
+  function packetHue(p) {
+    switch (p.kind) {
+      case "proof":   return 140;
+      case "refund":  return 0;
+      case "bid":     return 50;
+      case "request": return 210;
+      case "data":    return 295;
+      case "stream":  return p.from.hue;
+      default:        return p.from.hue;
+    }
+  }
+  function packetHeadColor(p) {
+    switch (p.kind) {
+      case "proof":  return "#34d399";
+      case "refund": return "#f87171";
+      case "bid":    return "#fbbf24";
+      case "data":   return "#f0abfc";
+      default:       return "#e7e9ee";
+    }
   }
 
-  // ─── side-panel renders ──────────────────────────────────────────────────
+  // ─── tick loop ────────────────────────────────────────────────────────────
+  function step() {
+    if (!paused) { tick++; sceneTick++; }
+    sceneTimeEl.textContent = (sceneTick / 60).toFixed(1) + "s";
+    tickEl.textContent = tick;
+
+    // glow phase + auto state
+    for (const a of ALL) {
+      if (!a._visible) continue;
+      if (a.state !== "awaitingApproval" && a.state !== "listening" && a.state !== "paying") {
+        const ratio = a.balance / Math.max(1, a.dailyCap);
+        if (ratio < 0.10 && a.wallet !== "contract" && a.wallet !== "provider" && a.wallet !== "oracle") a.state = "passive";
+        else a.state = "active";
+      }
+      a.glowPhase += 0.05;
+    }
+
+    // packets
+    if (!paused) {
+      for (let i = packets.length - 1; i >= 0; i--) {
+        const p = packets[i];
+        p.t += p.speed;
+        if (p.t >= 1) {
+          packets.splice(i, 1);
+          if (p.onArrive) p.onArrive(p);
+        }
+      }
+    }
+
+    if (!paused && currentScene && currentScene.tick) currentScene.tick(sceneTick);
+
+    draw();
+    requestAnimationFrame(step);
+  }
+
+  // ─── side panels ──────────────────────────────────────────────────────────
   function renderInfo() {
     if (!hoverId) {
       infoEl.innerHTML = `<div class="empty">hover an agent to inspect</div>`;
       return;
     }
-    const a = AGENTS.find(x => x.id === hoverId);
-    const pct = Math.min(100, (a.spent / a.dailyCap) * 100);
-    const over = a.spent > a.dailyCap * 0.9;
+    const a = A[hoverId];
+    const pct = Math.min(100, (a.spent / Math.max(1, a.dailyCap)) * 100);
+    const overCls = pct > 90 ? "over" : pct > 60 ? "warn" : "";
     infoEl.innerHTML = `
       <div class="name">${a.name}</div>
       <div class="role">${a.role}</div>
       <dl>
         <dt>wallet</dt><dd>${a.wallet}</dd>
         <dt>balance</dt><dd>${a.balance.toFixed(2)} USDC</dd>
-        <dt>daily cap</dt><dd>${a.dailyCap.toFixed(2)} USDC</dd>
-        <dt>spent today</dt><dd>${a.spent.toFixed(2)} USDC</dd>
+        <dt>daily cap</dt><dd>${a.dailyCap.toFixed(0)} USDC</dd>
+        <dt>spent</dt><dd>${a.spent.toFixed(2)} USDC</dd>
         <dt>priority</dt><dd><span class="tag ${a.priority}">${a.priority}</span></dd>
         <dt>state</dt><dd>${a.state}</dd>
         <dt>sig hue</dt><dd>h${a.hue}°</dd>
       </dl>
-      <div class="bar ${over ? "over" : ""}"><div style="width:${pct}%"></div></div>
+      <div class="bar ${overCls}"><div style="width:${pct}%"></div></div>
     `;
   }
 
   function log(html) {
     const row = document.createElement("div");
     row.className = "row";
-    row.innerHTML = `<span class="t">${String(tick).padStart(3, "0")}</span><span class="m">${html}</span>`;
+    const t = String(sceneTick).padStart(4, "0");
+    row.innerHTML = `<span class="t">${t}</span><span class="m">${html}</span>`;
     logEl.prepend(row);
-    while (logEl.children.length > 60) logEl.lastChild.remove();
+    while (logEl.children.length > 80) logEl.lastChild.remove();
   }
+
+  function setCaption(step, html) {
+    captionEl.innerHTML = `<span class="step">${step}</span>${html}`;
+  }
+
+  // ─── HITL approval button helper ──────────────────────────────────────────
+  function showApprove(agent, label, onApprove) {
+    if (agent._approveBtn) return;
+    agent.state = "awaitingApproval";
+    const btn = document.createElement("button");
+    btn.className = "approve";
+    btn.textContent = label;
+    const r = cvs.getBoundingClientRect();
+    btn.style.left = (r.left + agent.pos.x) + "px";
+    btn.style.top  = (r.top  + agent.pos.y - agent.radius - 24) + "px";
+    document.body.appendChild(btn);
+    btn.addEventListener("click", () => {
+      btn.remove();
+      agent._approveBtn = null;
+      agent.state = "active";
+      onApprove();
+    });
+    agent._approveBtn = btn;
+  }
+  function clearApprovals() {
+    for (const a of ALL) {
+      if (a._approveBtn) { a._approveBtn.remove(); a._approveBtn = null; }
+    }
+  }
+
+  // ─── scenes ───────────────────────────────────────────────────────────────
+  let currentScene = null;
+  const SCENES = {};
+
+  function setVisible(ids) {
+    for (const a of ALL) a._visible = false;
+    for (const id of ids) if (A[id]) A[id]._visible = true;
+  }
+  function ring(ids, cx, cy, r, startAng = -Math.PI/2) {
+    ids.forEach((id, i) => {
+      const ang = startAng + (i / ids.length) * Math.PI * 2;
+      A[id].pos.x = cx + Math.cos(ang) * r;
+      A[id].pos.y = cy + Math.sin(ang) * r;
+    });
+  }
+  function row(ids, y, x0, x1) {
+    ids.forEach((id, i) => {
+      const t = ids.length === 1 ? 0.5 : i / (ids.length - 1);
+      A[id].pos.x = lerp(x0, x1, t);
+      A[id].pos.y = y;
+    });
+  }
+
+  // — Scene 1: x402 paywall —————————————————————————————————————————————
+  SCENES.x402 = {
+    id: "x402",
+    name: "HTTP-402 paywall",
+    short: "01",
+    desc: "An <code>x402</code>-style paywall. Caller hits a paid endpoint, gets back <code>402 Payment Required</code> with an <code>accepts[]</code> envelope, signs an <code>X-Payment-Proof</code> header, retries, and is served. Off-chain HTTP, on-chain settlement on the bottom rail.",
+    enter() {
+      setVisible(["bob", "eli"]);
+      A.bob.balance = 6; A.bob.spent = 0;
+      A.eli.balance = 1;
+      this.layout(); this.phase = 0; this.cool = 0;
+      setCaption("step 1 / 4", "<code>GET /inference</code> — <strong>Bob</strong> calls <strong>Eli</strong>'s endpoint cold, no <code>X-Payment-Proof</code> header attached.");
+      log(`<span class="info">x402</span> scene loaded`);
+    },
+    layout() {
+      A.bob.pos = { x: W * 0.28, y: H * 0.5 };
+      A.eli.pos = { x: W * 0.72, y: H * 0.5 };
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      if (this.phase === 0 && t % 220 === 30) {
+        emit("bob", "eli", { kind: "request", label: "GET /infer", speed: 0.018 });
+        log(`Bob → Eli: <code>GET /inference</code>`);
+        this.phase = 1; this.cool = 60;
+      } else if (this.phase === 1) {
+        emit("eli", "bob", { kind: "request", label: "402 + accepts[]", speed: 0.018 });
+        log(`Eli → Bob: <span class="warn">402 Payment Required</span> · 0.001 USDC`);
+        setCaption("step 2 / 4", "Eli returns <code>402 Payment Required</code> with an <code>accepts[]</code> envelope describing the price and recipient.");
+        this.phase = 2; this.cool = 80;
+      } else if (this.phase === 2) {
+        emit("bob", "eli", { kind: "offer", label: "X-Payment-Proof", amount: 0.001, speed: 0.018,
+          onArrive: () => { A.bob.balance -= 0.001; A.eli.balance += 0.001; A.bob.spent += 0.001; }});
+        log(`Bob → Eli: <code>X-Payment-Proof</code> 0.001 USDC`);
+        setCaption("step 3 / 4", "Bob signs an <code>X-Payment-Proof</code> header and retries. Payment settles on-chain in the background.");
+        this.phase = 3; this.cool = 80;
+      } else if (this.phase === 3) {
+        emit("eli", "bob", { kind: "proof", label: "200 OK", speed: 0.018 });
+        log(`Eli → Bob: <span class="ok">200 OK</span> · inference result`);
+        setCaption("step 4 / 4", "Eli verifies the proof, serves <code>200 OK</code> with the inference result. Loop repeats — every paid call costs Bob 0.001 USDC.");
+        jobs++; jobsEl.textContent = jobs;
+        this.phase = 0; this.cool = 140;
+      }
+    },
+    onAgentClick(a) {
+      if (a.id === "bob" && this.phase === 0) { this.cool = 0; }
+    },
+  };
+
+  // — Scene 2: Escrow (happy + refund) ————————————————————————————————————
+  SCENES.escrow = {
+    id: "escrow",
+    name: "Escrow + refund",
+    short: "02",
+    desc: "Trust-minimized A2A via <code>AgentEscrow.sol</code>. Payer locks funds, payee delivers, payer confirms → release. If payee goes silent past <code>timeout_blocks + challenge_period</code>, payer reclaims.",
+    enter() {
+      setVisible(["alice", "gus", "escrow", "deva", "hana"]);
+      A.alice.balance = 10; A.gus.balance = 1;
+      A.deva.balance = 10; A.hana.balance = 0.5;
+      this.layout();
+      this.phase = 0; this.cool = 60; this.block = 0; this.refundBlock = 0;
+      setCaption("step 1 / 5", "Two parallel flows. <strong>Alice → Gus</strong> follows the happy path. <strong>Deva → Hana</strong> will demonstrate the refund path.");
+      log(`<span class="info">escrow</span> scene loaded · two parallel flows`);
+    },
+    layout() {
+      A.escrow.pos = { x: W * 0.5,  y: H * 0.5 };
+      A.alice.pos  = { x: W * 0.18, y: H * 0.3 };
+      A.gus.pos    = { x: W * 0.82, y: H * 0.3 };
+      A.deva.pos   = { x: W * 0.18, y: H * 0.75 };
+      A.hana.pos   = { x: W * 0.82, y: H * 0.75 };
+    },
+    drawChannels(ctx) {
+      ctx.save();
+      ctx.strokeStyle = "rgba(96, 165, 250, 0.18)";
+      ctx.lineWidth = 1; ctx.setLineDash([5, 5]);
+      [["alice","escrow"],["gus","escrow"],["deva","escrow"],["hana","escrow"]].forEach(([a,b]) => {
+        ctx.beginPath();
+        ctx.moveTo(A[a].pos.x, A[a].pos.y);
+        ctx.lineTo(A[b].pos.x, A[b].pos.y);
+        ctx.stroke();
+      });
+      ctx.setLineDash([]); ctx.restore();
+    },
+    drawOverlay(ctx, W, H) {
+      // block counter near the escrow contract
+      ctx.fillStyle = "rgba(138, 147, 163, 0.85)";
+      ctx.font = "10px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText("block #" + this.block, A.escrow.pos.x, A.escrow.pos.y + A.escrow.radius + 16);
+      // refund-path countdown if relevant
+      if (this.phase >= 3 && this.phase < 6) {
+        const remaining = Math.max(0, this.refundBlock - this.block);
+        ctx.fillStyle = remaining ? "rgba(248, 113, 113, 0.9)" : "rgba(52, 211, 153, 0.9)";
+        ctx.fillText(remaining ? `refund in ${remaining} blocks` : "refund window open",
+          (A.deva.pos.x + A.hana.pos.x) / 2, (A.deva.pos.y + A.hana.pos.y) / 2 - 10);
+      }
+    },
+    tick(t) {
+      if (t % 30 === 0) this.block++;
+      if (this.cool > 0) { this.cool--; return; }
+      if (this.phase === 0) {
+        // Alice locks 2.5 in escrow
+        emit("alice", "escrow", { kind: "offer", label: "lock 2.5", amount: 2.5, speed: 0.014,
+          onArrive: () => { A.alice.balance -= 2.5; A.escrow.balance += 2.5; }});
+        log(`Alice → Escrow: <code>createPayment(request_id, gus, 2.5 USDC)</code>`);
+        setCaption("step 2 / 5", "<strong>Alice</strong> calls <code>createPayment()</code>, locking 2.5 USDC in the <span class=\"pill\">Escrow</span> contract.");
+        this.phase = 1; this.cool = 80;
+      } else if (this.phase === 1) {
+        // Gus delivers work (data packet to Alice)
+        emit("gus", "alice", { kind: "data", label: "deliverable", speed: 0.016 });
+        log(`Gus → Alice: deliverable submitted`);
+        setCaption("step 3 / 5", "<strong>Gus</strong> performs the work off-chain and delivers the artifact.");
+        this.phase = 2; this.cool = 80;
+      } else if (this.phase === 2) {
+        // Alice confirms, escrow releases to Gus
+        emit("alice", "escrow", { kind: "request", label: "confirm", speed: 0.018,
+          onArrive: () => {
+            emit("escrow", "gus", { kind: "proof", label: "released 2.5", amount: 2.5, speed: 0.018,
+              onArrive: () => { A.escrow.balance -= 2.5; A.gus.balance += 2.5; jobs++; jobsEl.textContent = jobs; }});
+          }});
+        log(`Alice → Escrow: <code>confirmPayment(request_id)</code> · <span class="ok">released to Gus</span>`);
+        setCaption("step 4 / 5", "Alice calls <code>confirmPayment()</code> → escrow releases 2.5 USDC to Gus.");
+        this.phase = 3; this.cool = 100;
+        // Kick off refund-path scenario
+        this.refundBlock = this.block + 20;
+        emit("deva", "escrow", { kind: "offer", label: "lock 1.0", amount: 1.0, speed: 0.014,
+          onArrive: () => { A.deva.balance -= 1.0; A.escrow.balance += 1.0; }});
+        log(`Deva → Escrow: <code>createPayment(..., hana, 1.0 USDC)</code>`);
+      } else if (this.phase === 3 && this.block >= this.refundBlock) {
+        log(`<span class="warn">Hana silent</span> — refund window opens at block ${this.block}`);
+        setCaption("step 5 / 5", "Deva's counterparty <strong>Hana</strong> went silent past <code>timeout_blocks + challenge_period</code>. Deva reclaims via <code>requestRefund()</code>.");
+        this.phase = 4; this.cool = 60;
+      } else if (this.phase === 4) {
+        emit("deva", "escrow", { kind: "request", label: "requestRefund", speed: 0.018,
+          onArrive: () => {
+            emit("escrow", "deva", { kind: "refund", label: "refunded 1.0", amount: 1.0, speed: 0.018,
+              onArrive: () => { A.escrow.balance -= 1.0; A.deva.balance += 1.0; }});
+          }});
+        log(`Escrow → Deva: <span class="hot">refunded 1.0 USDC</span>`);
+        this.phase = 5; this.cool = 180;
+      } else if (this.phase === 5) {
+        this.phase = 0; this.cool = 60;
+        A.alice.balance = 10; A.gus.balance = 1;
+        A.deva.balance = 10; A.hana.balance = 0.5;
+      }
+    },
+  };
+
+  // — Scene 3: Streaming MPP ————————————————————————————————————————————
+  SCENES.stream = {
+    id: "stream",
+    name: "Streaming micropayments",
+    short: "03",
+    desc: "Multi-party / streaming pay: Alice opens a budget-capped session with Eli, and pays per chunk as inference tokens stream back. Like x402's <code>STREAMING</code> scheme — small, fast, capped.",
+    enter() {
+      setVisible(["alice", "eli"]);
+      A.alice.balance = 5; A.alice.spent = 0; A.alice.dailyCap = 5;
+      A.eli.balance = 0;
+      this.layout();
+      this.tokensServed = 0;
+      this.budget = 5.0;
+      setCaption("step 1 / 2", "Session opened. Cap is 5 USDC. Each chunk = 0.02 USDC. Alice's balance drains as Eli's grows; session auto-closes at cap.");
+      log(`<span class="info">stream</span> scene loaded · cap 5.00 USDC, 0.02 USDC/chunk`);
+    },
+    layout() {
+      A.alice.pos = { x: W * 0.22, y: H * 0.5 };
+      A.eli.pos   = { x: W * 0.78, y: H * 0.5 };
+    },
+    drawOverlay(ctx, W, H) {
+      // progress bar between them
+      const x = (A.alice.pos.x + A.eli.pos.x) / 2;
+      const y = (A.alice.pos.y + A.eli.pos.y) / 2 - 80;
+      const w = 220;
+      const pct = Math.min(1, A.alice.spent / Math.max(0.01, this.budget));
+      ctx.fillStyle = "rgba(13, 16, 21, 0.85)";
+      ctx.strokeStyle = "rgba(35, 39, 47, 0.9)";
+      ctx.fillRect(x - w/2, y, w, 22);
+      ctx.strokeRect(x - w/2, y, w, 22);
+      ctx.fillStyle = pct < 0.85 ? "rgba(52, 211, 153, 0.75)" : "rgba(248, 113, 113, 0.85)";
+      ctx.fillRect(x - w/2 + 2, y + 2, (w - 4) * pct, 18);
+      ctx.fillStyle = "rgba(231, 233, 238, 0.85)";
+      ctx.font = "11px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(`session ${A.alice.spent.toFixed(2)} / ${this.budget.toFixed(2)} USDC · ${this.tokensServed} chunks`, x, y - 6);
+    },
+    tick(t) {
+      if (A.alice.spent >= this.budget) {
+        if (!this.closed) {
+          this.closed = true;
+          log(`<span class="warn">session closed at cap</span> · ${this.tokensServed} chunks`);
+          setCaption("step 2 / 2", `Cap reached — session auto-closes. Total served: <strong>${this.tokensServed}</strong> chunks for <strong>${A.alice.spent.toFixed(2)} USDC</strong>.`);
+        }
+        if (t % 240 === 0) {
+          A.alice.spent = 0; A.alice.balance = 5; A.eli.balance = 0;
+          this.tokensServed = 0; this.closed = false;
+        }
+        return;
+      }
+      if (t % 8 === 0) {
+        emit("alice", "eli", { kind: "stream", label: "", amount: 0.02, speed: 0.04,
+          onArrive: () => {
+            A.alice.balance -= 0.02; A.alice.spent += 0.02;
+            A.eli.balance += 0.02; this.tokensServed++;
+            if (this.tokensServed % 25 === 0) jobs++; jobsEl.textContent = jobs;
+          }});
+      }
+    },
+  };
+
+  // — Scene 4: AI compute auction ——————————————————————————————————————————
+  SCENES.auction = {
+    id: "auction",
+    name: "AI compute auction",
+    short: "04",
+    desc: "Marketplace flow. <strong>Iris</strong> broadcasts a job (transcribe 10 minutes of audio). <strong>Eli</strong>, <strong>Gus</strong>, and <strong>Hana</strong> bid. Lowest bid wins; payment goes through escrow.",
+    enter() {
+      setVisible(["iris", "eli", "gus", "hana", "escrow"]);
+      A.iris.balance = 12; A.iris.spent = 0;
+      A.eli.balance = 1; A.gus.balance = 1; A.hana.balance = 1;
+      this.layout();
+      this.phase = 0; this.cool = 60;
+      this.bids = [];
+      A.eli.state = "listening"; A.gus.state = "listening"; A.hana.state = "listening";
+      setCaption("step 1 / 4", "Iris is about to broadcast a job to the listening providers.");
+      log(`<span class="info">auction</span> scene loaded`);
+    },
+    layout() {
+      A.iris.pos = { x: W * 0.2, y: H * 0.5 };
+      A.escrow.pos = { x: W * 0.55, y: H * 0.75 };
+      ring(["eli", "gus", "hana"], W * 0.72, H * 0.5, 130, -Math.PI/2);
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      if (this.phase === 0) {
+        ["eli","gus","hana"].forEach(id => emit("iris", id, { kind: "request", label: "RFQ", speed: 0.02 }));
+        log(`Iris broadcasts RFQ to ${3} providers`);
+        setCaption("step 2 / 4", "RFQ fans out. Providers price the job and respond with bids.");
+        this.phase = 1; this.cool = 70;
+      } else if (this.phase === 1) {
+        const bids = { eli: 1.20, gus: 0.90, hana: 1.05 };
+        Object.entries(bids).forEach(([id, price], i) => {
+          setTimeout(() => {
+            emit(id, "iris", { kind: "bid", label: `${price.toFixed(2)} USDC`, speed: 0.02,
+              onArrive: () => this.bids.push({ id, price }) });
+            log(`<span class="warn">${A[id].name}</span> bids ${price.toFixed(2)} USDC`);
+          }, i * 400);
+        });
+        this.phase = 2; this.cool = 120;
+      } else if (this.phase === 2) {
+        const winner = this.bids.sort((a,b) => a.price - b.price)[0];
+        if (!winner) { this.cool = 30; return; }
+        this.winner = winner;
+        ["eli","gus","hana"].forEach(id => { if (id !== winner.id) A[id].state = "passive"; });
+        log(`<span class="ok">${A[winner.id].name} wins</span> at ${winner.price.toFixed(2)} USDC`);
+        setCaption("step 3 / 4", `<strong>${A[winner.id].name}</strong> wins the auction. Iris locks funds in escrow.`);
+        emit("iris", "escrow", { kind: "offer", label: "lock " + winner.price.toFixed(2),
+          amount: winner.price, speed: 0.018,
+          onArrive: () => { A.iris.balance -= winner.price; A.escrow.balance += winner.price; }});
+        this.phase = 3; this.cool = 100;
+      } else if (this.phase === 3) {
+        // delivery + release
+        const w = this.winner;
+        emit(w.id, "iris", { kind: "data", label: "transcript", speed: 0.018 });
+        setTimeout(() => {
+          emit("iris", "escrow", { kind: "request", label: "confirm", speed: 0.02,
+            onArrive: () => {
+              emit("escrow", w.id, { kind: "proof", label: `released ${w.price.toFixed(2)}`, speed: 0.02,
+                onArrive: () => {
+                  A.escrow.balance -= w.price; A[w.id].balance += w.price;
+                  jobs++; jobsEl.textContent = jobs;
+                }});
+            }});
+        }, 1200);
+        setCaption("step 4 / 4", `Provider delivers → Iris confirms → escrow releases ${w.price.toFixed(2)} USDC. Losing bids cost nothing.`);
+        this.phase = 4; this.cool = 220;
+      } else if (this.phase === 4) {
+        // reset
+        this.bids = []; this.winner = null;
+        ["eli","gus","hana"].forEach(id => { A[id].state = "listening"; A[id].balance = 1; });
+        A.iris.balance = 12;
+        this.phase = 0; this.cool = 60;
+      }
+    },
+  };
+
+  // — Scene 5: HITL gate ——————————————————————————————————————————————————
+  SCENES.hitl = {
+    id: "hitl",
+    name: "Human-in-the-loop gate",
+    short: "05",
+    desc: "Risky spend? <strong>Deva</strong> is a HITL wallet. Any spend above a threshold raises an <strong>Approve</strong> button — release requires a human click. Small spends pass automatically.",
+    enter() {
+      setVisible(["deva", "eli", "gus"]);
+      A.deva.balance = 50; A.deva.spent = 0; A.deva.dailyCap = 80;
+      A.eli.balance = 1; A.gus.balance = 1;
+      this.layout();
+      this.phase = 0; this.cool = 60;
+      setCaption("step 1 / 3", "Click <strong>Deva</strong> to initiate a spend. Small purchases pass; large ones raise an <strong>Approve</strong> button.");
+      log(`<span class="info">hitl</span> scene loaded · threshold = 5 USDC`);
+    },
+    layout() {
+      A.deva.pos = { x: W * 0.5, y: H * 0.7 };
+      A.eli.pos  = { x: W * 0.3, y: H * 0.3 };
+      A.gus.pos  = { x: W * 0.7, y: H * 0.3 };
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      if (this.phase === 0 && t % 200 === 50) {
+        const target = Math.random() < 0.5 ? "eli" : "gus";
+        const amount = Math.random() < 0.5 ? 1.5 : 12;       // mix small/large
+        if (amount >= 5) {
+          showApprove(A.deva, `approve ${amount.toFixed(2)} USDC`, () => {
+            emit("deva", target, { kind: "offer", label: `${amount.toFixed(2)} USDC`,
+              amount, speed: 0.018,
+              onArrive: () => { A.deva.balance -= amount; A[target].balance += amount;
+                jobs++; jobsEl.textContent = jobs; }});
+            log(`<span class="ok">approved</span> · ${amount.toFixed(2)} USDC → ${A[target].name}`);
+          });
+          log(`<span class="warn">gate</span> · ${amount.toFixed(2)} USDC > 5 USDC threshold — awaiting human`);
+          setCaption("step 2 / 3", "Above-threshold spend. Click <strong>Approve</strong> to release.");
+        } else {
+          emit("deva", target, { kind: "offer", label: `${amount.toFixed(2)} USDC`,
+            amount, speed: 0.018,
+            onArrive: () => { A.deva.balance -= amount; A[target].balance += amount;
+              jobs++; jobsEl.textContent = jobs; }});
+          log(`auto-pay · ${amount.toFixed(2)} USDC → ${A[target].name}`);
+          setCaption("step 3 / 3", "Sub-threshold spend passes automatically.");
+        }
+        this.cool = 220;
+      }
+    },
+    onAgentClick(a) {
+      if (a.id === "deva" && this.cool > 100) this.cool = 0;
+    },
+  };
+
+  // — Scene 6: Treasury rebalance ————————————————————————————————————————
+  SCENES.fanout = {
+    id: "fanout",
+    name: "Treasury rebalance",
+    short: "06",
+    desc: "Fan-out from one balance source. <strong>Fina</strong> watches her agentic wallets; if one drops below a floor, she refills it. A common pattern for fleets of autonomous agents.",
+    enter() {
+      setVisible(["fina", "alice", "bob", "iris", "juno"]);
+      A.fina.balance = 80; A.fina.dailyCap = 100;
+      A.alice.balance = 0.5; A.alice.dailyCap = 4;
+      A.bob.balance   = 1.2; A.bob.dailyCap   = 4;
+      A.iris.balance  = 0.3; A.iris.dailyCap  = 4;
+      A.juno.balance  = 3.5; A.juno.dailyCap  = 4;
+      this.layout();
+      this.cool = 30;
+      setCaption("step 1 / 2", "Fleet wallets running low (frosted = below floor). Treasury detects on its sweep tick.");
+      log(`<span class="info">fanout</span> scene loaded · floor = 1.0 USDC`);
+    },
+    layout() {
+      A.fina.pos = { x: W * 0.5, y: H * 0.5 };
+      ring(["alice","bob","iris","juno"], W * 0.5, H * 0.5, Math.min(W, H) * 0.32);
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      if (t % 30 === 0) {
+        let refilled = 0;
+        ["alice","bob","iris","juno"].forEach(id => {
+          if (A[id].balance < 1.0) {
+            const top = 3.5 - A[id].balance;
+            emit("fina", id, { kind: "offer", label: `+${top.toFixed(2)}`, amount: top, speed: 0.02,
+              onArrive: () => { A.fina.balance -= top; A[id].balance += top; }});
+            log(`Fina → ${A[id].name}: top up ${top.toFixed(2)} USDC`);
+            refilled++;
+          }
+        });
+        if (refilled) setCaption("step 2 / 2", `Treasury fans out ${refilled} top-up payment(s). Recipients brighten back to active.`);
+        this.cool = 180;
+        // simulate continued spending
+        ["alice","bob","iris","juno"].forEach(id => { A[id].balance = Math.max(0, A[id].balance - 0.7); });
+      }
+    },
+  };
+
+  // — Scene 7: On-chain oracle pull ——————————————————————————————————————————
+  SCENES.oracle = {
+    id: "oracle",
+    name: "On-chain oracle pull",
+    short: "07",
+    desc: "AI-on-chain pattern. <strong>Chen</strong> sells signed price quotes. <strong>Alice</strong>, <strong>Bob</strong>, and <strong>Iris</strong> pull on demand and pay per-query. Signed responses fold into the PQ-signed-envelope work tracked in <a href=\"https://github.com/kcolbchain/switchboard/issues/33\">#33</a>.",
+    enter() {
+      setVisible(["chen", "alice", "bob", "iris"]);
+      A.chen.balance = 12;
+      A.alice.balance = 6; A.bob.balance = 6; A.iris.balance = 6;
+      A.alice.spent = 0; A.bob.spent = 0; A.iris.spent = 0;
+      this.layout();
+      this.cool = 30;
+      setCaption("step 1 / 2", "Three buyers pull from one oracle, asynchronously. Each query costs 0.05 USDC; the oracle returns a signed quote.");
+      log(`<span class="info">oracle</span> scene loaded · 0.05 USDC / query`);
+    },
+    layout() {
+      A.chen.pos = { x: W * 0.5, y: H * 0.5 };
+      ring(["alice","bob","iris"], W * 0.5, H * 0.5, Math.min(W, H) * 0.32);
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      // each buyer pulls at its own cadence
+      const buyers = [
+        { id: "alice", every: 90 },
+        { id: "bob",   every: 130 },
+        { id: "iris",  every: 70 },
+      ];
+      buyers.forEach(b => {
+        if (t % b.every === 0 && A[b.id].balance > 0.1) {
+          emit(b.id, "chen", { kind: "request", label: "quote?", speed: 0.022,
+            onArrive: () => {
+              emit("chen", b.id, { kind: "data", label: "signed quote · 0.05 USDC",
+                amount: 0.05, speed: 0.022,
+                onArrive: () => {
+                  A[b.id].balance -= 0.05; A[b.id].spent += 0.05;
+                  A.chen.balance  += 0.05;
+                  jobs++; jobsEl.textContent = jobs;
+                }});
+            }});
+          log(`${A[b.id].name} ⇄ Chen: quote pulled · 0.05 USDC`);
+        }
+      });
+      setCaption("step 2 / 2", `Asynchronous pulls; each response is a signed envelope. With <a href="https://github.com/kcolbchain/switchboard/issues/37">PQ-4</a> live, buyers verify <em>before</em> paying.`);
+    },
+  };
+
+  // ─── scene registry & switcher ────────────────────────────────────────────
+  const SCENE_ORDER = ["x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle"];
+
+  function selectScene(id, force) {
+    if (!force && currentScene && currentScene.id === id) return;
+    packets.length = 0;
+    clearApprovals();
+    sceneTick = 0;
+    for (const s of ALL) { s.state = "active"; s.spent = 0; }
+    currentScene = SCENES[id];
+    currentScene.enter();
+    // header
+    document.getElementById("sceneTitle").textContent = currentScene.name;
+    document.getElementById("sceneDesc").innerHTML   = currentScene.desc;
+    document.querySelectorAll("#sceneBar button").forEach(b => {
+      b.classList.toggle("active", b.dataset.scene === id);
+    });
+    log(`<span class="seg">— scene switched to <strong>${currentScene.name}</strong> —</span>`);
+  }
+
+  const sceneBar = document.getElementById("sceneBar");
+  SCENE_ORDER.forEach(id => {
+    const s = SCENES[id];
+    const b = document.createElement("button");
+    b.dataset.scene = id;
+    b.innerHTML = `<span class="num">${s.short}</span>${s.name}`;
+    b.addEventListener("click", () => selectScene(id));
+    sceneBar.appendChild(b);
+  });
 
   // ─── go ───────────────────────────────────────────────────────────────────
   resize();
-  layout();
+  selectScene("x402");
   requestAnimationFrame(step);
-
-  // small ambient action so the canvas isn't dead on load
-  setInterval(() => {
-    if (paused) return;
-    const eligible = AGENTS.filter(a => a.state === "active" && a.balance > 1);
-    if (!eligible.length) return;
-    const a = eligible[Math.floor(Math.random() * eligible.length)];
-    if (Math.random() < 0.4) initiatePayment(a, false);
-  }, 2200);
 })();
 </script>
 

--- a/web/agents-demo.html
+++ b/web/agents-demo.html
@@ -82,7 +82,14 @@
   .scene-bar button.active { background: rgba(96, 165, 250, 0.12);
     color: var(--fg); border-color: rgba(96, 165, 250, 0.5); }
   .scene-bar button .num { color: var(--muted-2); font-family: var(--mono); font-size: 11px; }
-  .scene-bar .sep { width: 1px; height: 16px; background: rgba(255, 255, 255, 0.08); margin: 0 2px; }
+  .scene-bar .sep { width: 1px; height: 16px; background: rgba(255, 255, 255, 0.08); margin: 0 4px; }
+  .scene-bar .add-scene { color: var(--muted); border: 1px dashed rgba(255, 255, 255, 0.12);
+    border-radius: 999px; padding: 5px 11px; font-size: 11.5px;
+    display: inline-flex; align-items: center; gap: 6px; white-space: nowrap;
+    transition: color 0.15s, border-color 0.15s, background 0.15s; }
+  .scene-bar .add-scene:hover { color: var(--fg); border-color: var(--accent);
+    background: rgba(96, 165, 250, 0.08); text-decoration: none; }
+  .scene-bar .add-scene .plus { color: var(--accent); font-size: 14px; line-height: 1; }
 
   .layout { display: grid; grid-template-columns: 250px 1fr 300px;
     height: calc(100vh - 95px); gap: 0; }
@@ -123,9 +130,19 @@
   .empty { color: var(--muted-2); font-style: italic; font-size: 11px; }
 
   .legend { font-size: 11px; color: var(--muted); line-height: 1.8; }
+  .legend.small { line-height: 1.5; }
   .legend .dot { display: inline-block; width: 7px; height: 7px;
-    border-radius: 50%; vertical-align: 1px; margin-right: 6px; }
+    border-radius: 50%; vertical-align: 1px; margin-right: 7px; }
   .legend .row-key { color: var(--fg); }
+  .legend .shape { display: inline-block; width: 11px; height: 11px;
+    vertical-align: -1px; margin-right: 7px; border: 1px solid var(--muted-2); }
+  .legend .shape.sq { border-radius: 4px; background: rgba(125, 211, 252, 0.15); border-color: var(--agentic); }
+  .legend .shape.oc { clip-path: polygon(30% 0,70% 0,100% 30%,100% 70%,70% 100%,30% 100%,0 70%,0 30%);
+    background: rgba(52, 211, 153, 0.18); border: none;
+    box-shadow: 0 0 0 1px var(--provider); }
+  .legend .shape.hx { clip-path: polygon(50% 0,100% 25%,100% 75%,50% 100%,0 75%,0 25%);
+    background: rgba(96, 165, 250, 0.18); border: none;
+    box-shadow: 0 0 0 1px var(--accent); }
 
   .log { font-family: var(--mono); font-size: 10px; line-height: 1.5; }
   .log .row { padding: 3px 0; border-bottom: 1px dashed var(--border);
@@ -174,20 +191,32 @@
     color: var(--muted); margin: 0 3px; font-family: var(--mono); }
 
   .tt { position: fixed; pointer-events: none; z-index: 50;
-    background: rgba(13, 16, 21, 0.94); border: 1px solid var(--border);
-    border-radius: 6px; padding: 8px 10px; font-size: 11px; min-width: 180px;
+    background: rgba(13, 16, 21, 0.88);
+    backdrop-filter: blur(14px) saturate(150%);
+    -webkit-backdrop-filter: blur(14px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px; padding: 9px 11px; font-size: 11px; min-width: 220px; max-width: 260px;
     opacity: 0; transform: translateY(-2px);
     transition: opacity 0.12s, transform 0.12s;
-    box-shadow: 0 6px 24px rgba(0,0,0,0.5); }
+    box-shadow: 0 12px 38px rgba(0,0,0,0.55); }
   .tt.show { opacity: 1; transform: translateY(0); }
-  .tt .ttname { font-weight: 600; font-size: 12px; color: var(--fg); }
-  .tt .ttrole { color: var(--muted); font-size: 10px; margin-bottom: 6px; }
-  .tt .ttkind { display: inline-block; padding: 1px 5px; border-radius: 3px;
-    border: 1px solid; font-size: 10px; font-family: var(--mono); margin-bottom: 6px; }
-  .tt dl { margin: 4px 0 0 0; display: grid; grid-template-columns: auto 1fr;
-    gap: 2px 8px; font-family: var(--mono); font-size: 10px; }
+  .tt .ttname { font-weight: 600; font-size: 12px; color: var(--fg); letter-spacing: 0.01em; }
+  .tt .ttrole { color: var(--muted); font-size: 10px; margin-bottom: 8px; }
+  .tt .ttrow { display: flex; gap: 5px; margin-bottom: 4px; flex-wrap: wrap; }
+  .tt .ttkind { display: inline-block; padding: 1px 6px; border-radius: 999px;
+    border: 1px solid currentColor; font-size: 9.5px; font-family: var(--mono);
+    line-height: 1.4; letter-spacing: 0.02em; }
+  .tt .ttdesc { color: var(--muted); font-size: 10px; margin-bottom: 8px;
+    padding-bottom: 8px; border-bottom: 1px dashed rgba(255,255,255,0.06); }
+  .tt .ttproto-row { display: flex; gap: 4px; flex-wrap: wrap; margin-bottom: 8px; }
+  .tt .ttproto { display: inline-block; padding: 1px 6px; border-radius: 3px;
+    background: rgba(96, 165, 250, 0.10); border: 1px solid rgba(96, 165, 250, 0.25);
+    color: var(--info); font-size: 9.5px; font-family: var(--mono); }
+  .tt .ttproto.muted { background: transparent; border-color: var(--border); color: var(--muted-2); }
+  .tt dl { margin: 0; display: grid; grid-template-columns: auto 1fr;
+    gap: 2px 10px; font-family: var(--mono); font-size: 10px; }
   .tt dt { color: var(--muted-2); }
-  .tt dd { margin: 0; color: var(--fg); }
+  .tt dd { margin: 0; color: var(--fg); text-align: right; }
 
   .approve { position: absolute; pointer-events: auto;
     background: var(--panel); border: 1px solid var(--warn); color: var(--warn);
@@ -237,14 +266,26 @@
       <div class="empty">hover an agent to inspect</div>
     </div>
 
-    <h2>Legend</h2>
+    <h2>Shapes</h2>
     <div class="legend">
-      <div><span class="dot" style="background: var(--agentic)"></span><span class="row-key">agentic</span> — auto-pays</div>
-      <div><span class="dot" style="background: var(--hitl)"></span><span class="row-key">human-in-loop</span> — gates spend</div>
-      <div><span class="dot" style="background: var(--treasury)"></span><span class="row-key">treasury</span> — high balance, low velocity</div>
-      <div><span class="dot" style="background: var(--provider)"></span><span class="row-key">provider</span> — sells work</div>
-      <div><span class="dot" style="background: var(--oracle)"></span><span class="row-key">oracle</span> — sells data</div>
-      <div><span class="dot" style="background: var(--accent)"></span><span class="row-key">contract / repo</span> — hex shape</div>
+      <div><span class="shape sq"></span><span class="row-key">human</span> — Patty, Abhi, Tridib</div>
+      <div><span class="shape oc"></span><span class="row-key">bot</span> — autonomous agents</div>
+      <div><span class="shape hx"></span><span class="row-key">contract</span> — on-chain entities</div>
+    </div>
+
+    <h2>Wallet types</h2>
+    <div class="legend">
+      <div><span class="dot" style="background: var(--agentic)"></span><span class="row-key">agentic</span> · auto-pays</div>
+      <div><span class="dot" style="background: var(--hitl)"></span><span class="row-key">HITL</span> · gates spend</div>
+      <div><span class="dot" style="background: var(--treasury)"></span><span class="row-key">treasury</span> · funds fleets</div>
+      <div><span class="dot" style="background: var(--provider)"></span><span class="row-key">provider</span> · sells work</div>
+      <div><span class="dot" style="background: var(--oracle)"></span><span class="row-key">oracle</span> · sells data</div>
+    </div>
+
+    <h2>Developers</h2>
+    <div class="legend small">
+      Rip this apart — every scene is ~150 lines.
+      <a href="https://github.com/kcolbchain/switchboard/blob/main/web/SCENES.md" target="_blank" rel="noopener" style="color:var(--accent)">scene template ↗</a>
     </div>
   </aside>
 
@@ -307,9 +348,15 @@
   // Each agent has a unique signature hue — the visual stand-in for its
   // PQ public key. Hover reveals the conic gradient.
   function makeAgent(o) {
+    // Derive shape from kind if shape not provided.
+    const kind = o.kind || (o.wallet === "contract" ? "contract" :
+                            ["hitl","treasury"].includes(o.wallet) ? "human" : "bot");
+    const shape = o.shape || ({ human: "squircle", bot: "octagon", contract: "hex" }[kind]);
     return Object.assign({
       id: "", name: "", role: "",
-      wallet: "agentic",      // agentic | hitl | treasury | provider | oracle
+      kind,                    // human | bot | contract
+      shape,                   // squircle | octagon | hex (drives geometry)
+      wallet: "agentic",       // agentic | hitl | treasury | provider | oracle | contract
       hue: 0,
       balance: 5.0, dailyCap: 10.0, spent: 0,
       priority: "medium",
@@ -317,33 +364,38 @@
       radius: 32,
       glowPhase: Math.random() * Math.PI * 2,
       pos: { x: 0, y: 0 },
-      pinned: false,           // contracts/escrow rendered specially
-      shape: "circle",         // circle | hex (for contract / escrow)
+      protocols: [],           // ["x402","MPP","ZAP","escrow",...]
+      sigAlg: "ml-dsa-65",     // post-quantum default per docs/post-quantum.md
+      lastSeen: 0,             // bumped on every emit() to/from this agent
       meta: {},
       _approveBtn: null,
     }, o);
   }
 
   const A = {
-    alice:  makeAgent({ id: "alice",   name: "Alice",   role: "researcher",        wallet: "agentic",  hue: 195, balance: 8.0,  dailyCap: 12 }),
-    bob:    makeAgent({ id: "bob",     name: "Patty",   role: "data buyer",        wallet: "agentic",  hue: 145, balance: 6.0,  dailyCap: 10 }),
-    chen:   makeAgent({ id: "chen",    name: "Chen",    role: "price oracle",      wallet: "oracle",   hue: 295, balance: 30,   dailyCap: 80, radius: 38 }),
-    deva:   makeAgent({ id: "deva",    name: "Deva",    role: "trader",            wallet: "hitl",     hue:  40, balance: 4.0,  dailyCap: 25 }),
-    eli:    makeAgent({ id: "eli",     name: "Abhi",    role: "inference service", wallet: "provider", hue: 152, balance: 1.0,  dailyCap: 50, radius: 36 }),
-    fina:   makeAgent({ id: "fina",    name: "Fina",    role: "treasury",          wallet: "treasury", hue: 250, balance: 80,   dailyCap: 90, radius: 44 }),
-    gus:    makeAgent({ id: "gus",     name: "Tridib",  role: "image-gen service", wallet: "provider", hue:   8, balance: 0.5,  dailyCap: 40, radius: 36 }),
-    hana:   makeAgent({ id: "hana",    name: "Hana",    role: "embed service",     wallet: "provider", hue: 330, balance: 0.8,  dailyCap: 40, radius: 36 }),
-    iris:   makeAgent({ id: "iris",    name: "Iris",    role: "buyer",             wallet: "agentic",  hue: 180, balance: 6,    dailyCap: 12 }),
-    juno:   makeAgent({ id: "juno",    name: "Juno",    role: "buyer",             wallet: "agentic",  hue:  90, balance: 5,    dailyCap: 10 }),
-    escrow: makeAgent({ id: "escrow",  name: "Escrow",  role: "AgentEscrow.sol",   wallet: "contract", hue: 220, balance: 0, dailyCap: 999, radius: 30, shape: "hex" }),
+    // ── humans (Patty, Abhi, Tridib are the three protagonists) ──
+    bob:    makeAgent({ id: "bob",     name: "Patty",   role: "buyer · the user",       kind: "human", wallet: "agentic", hue: 195, balance: 6.0, dailyCap: 25, protocols: ["x402","MPP","escrow"], sigAlg: "hybrid (ecdsa+ml-dsa-65)" }),
+    eli:    makeAgent({ id: "eli",     name: "Abhi",    role: "service operator",       kind: "human", wallet: "provider",hue: 152, balance: 1.0, dailyCap: 50, radius: 36, protocols: ["x402","MPP","escrow"], sigAlg: "hybrid (ecdsa+ml-dsa-65)" }),
+    gus:    makeAgent({ id: "gus",     name: "Tridib",  role: "merchant / restaurateur",kind: "human", wallet: "provider",hue:   8, balance: 0.5, dailyCap: 40, radius: 36, protocols: ["x402","escrow"], sigAlg: "hybrid (ecdsa+ml-dsa-65)" }),
+    sara:   makeAgent({ id: "sara",    name: "Sara",    role: "friend at the bill",     kind: "human", wallet: "agentic", hue:  90, balance: 8, dailyCap: 15, protocols: ["x402"], sigAlg: "ml-dsa-65" }),
+    deva:   makeAgent({ id: "deva",    name: "Deva",    role: "discretionary trader",   kind: "human", wallet: "hitl",    hue:  40, balance: 4.0, dailyCap: 25, protocols: ["x402","escrow"], sigAlg: "hybrid (ecdsa+ml-dsa-65)" }),
+    driver: makeAgent({ id: "driver",  name: "Sai",     role: "taxi driver",            kind: "human", wallet: "provider",hue: 180, balance: 0,  dailyCap: 200, protocols: ["x402","escrow"], sigAlg: "ml-dsa-65" }),
+    rider:  makeAgent({ id: "rider",   name: "Kiran",   role: "delivery rider",         kind: "human", wallet: "provider",hue: 115, balance: 0,  dailyCap: 200, radius: 30, protocols: ["x402","escrow"], sigAlg: "ml-dsa-65" }),
 
-    // ── service agents for real-world use-case scenes ──
-    driver:  makeAgent({ id: "driver",  name: "Sai",      role: "taxi driver",         wallet: "provider", hue: 180, balance: 0,  dailyCap: 200, radius: 32 }),
-    dispatch:makeAgent({ id: "dispatch",name: "Dispatch", role: "ride-share matcher",  wallet: "contract", hue: 215, balance: 0,  dailyCap: 999, radius: 28, shape: "hex" }),
-    cafe:    makeAgent({ id: "cafe",    name: "Aroma",    role: "café POS",            wallet: "provider", hue:  28, balance: 0,  dailyCap: 200, radius: 34 }),
-    rest:    makeAgent({ id: "rest",    name: "Spice Hub",role: "restaurant",          wallet: "provider", hue:   8, balance: 0,  dailyCap: 200, radius: 34 }),
-    rider:   makeAgent({ id: "rider",   name: "Kiran",    role: "delivery rider",      wallet: "provider", hue: 115, balance: 0,  dailyCap: 200, radius: 30 }),
-    merchant:makeAgent({ id: "merchant",name: "Tridib's", role: "merchant (bill)",     wallet: "provider", hue:  60, balance: 0,  dailyCap: 999, radius: 36 }),
+    // ── bots / autonomous AI agents ──
+    alice:  makeAgent({ id: "alice",   name: "Alice",   role: "researcher AI",          kind: "bot", wallet: "agentic", hue: 200, balance: 8.0, dailyCap: 12, protocols: ["x402","MPP","ZAP"], sigAlg: "ml-dsa-65" }),
+    iris:   makeAgent({ id: "iris",    name: "Iris",    role: "buyer agent",            kind: "bot", wallet: "agentic", hue: 175, balance: 6, dailyCap: 12, protocols: ["x402","MPP"], sigAlg: "ml-dsa-65" }),
+    juno:   makeAgent({ id: "juno",    name: "Juno",    role: "buyer agent",            kind: "bot", wallet: "agentic", hue:  90, balance: 5, dailyCap: 10, protocols: ["x402"], sigAlg: "ml-dsa-65" }),
+    chen:   makeAgent({ id: "chen",    name: "Chen",    role: "price oracle",           kind: "bot", wallet: "oracle",  hue: 295, balance: 30, dailyCap: 80, radius: 38, protocols: ["x402","signed-data"], sigAlg: "ml-dsa-65" }),
+    fina:   makeAgent({ id: "fina",    name: "Fina",    role: "treasury algo",          kind: "bot", wallet: "treasury",hue: 250, balance: 80, dailyCap: 90, radius: 42, protocols: ["batch-escrow","x402"], sigAlg: "threshold + ml-dsa-65" }),
+    hana:   makeAgent({ id: "hana",    name: "Hana",    role: "embed service",          kind: "bot", wallet: "provider",hue: 330, balance: 0.8, dailyCap: 40, radius: 32, protocols: ["x402","ZAP"], sigAlg: "ml-dsa-65" }),
+    cafe:   makeAgent({ id: "cafe",    name: "Aroma POS", role: "Abhi's café surface",  kind: "bot", wallet: "provider",hue:  28, balance: 0, dailyCap: 200, radius: 32, protocols: ["x402"], sigAlg: "ml-dsa-65" }),
+    rest:   makeAgent({ id: "rest",    name: "Spice Hub POS", role: "Tridib's kitchen", kind: "bot", wallet: "provider",hue:   8, balance: 0, dailyCap: 200, radius: 32, protocols: ["x402","escrow"], sigAlg: "ml-dsa-65" }),
+    merchant:makeAgent({id: "merchant",name: "Bistro POS",   role: "merchant surface",  kind: "bot", wallet: "provider",hue:  60, balance: 0, dailyCap: 999, radius: 32, protocols: ["x402","escrow"], sigAlg: "ml-dsa-65" }),
+
+    // ── contracts / on-chain entities (hex) ──
+    escrow:  makeAgent({ id: "escrow",  name: "Escrow",   role: "AgentEscrow.sol",        kind: "contract", wallet: "contract", hue: 220, balance: 0, dailyCap: 999, radius: 30, protocols: ["escrow"], sigAlg: "ecdsa-secp256k1" }),
+    dispatch:makeAgent({ id: "dispatch",name: "Dispatch", role: "ride-share matcher",     kind: "contract", wallet: "contract", hue: 215, balance: 0, dailyCap: 999, radius: 28, protocols: ["matcher"], sigAlg: "ecdsa-secp256k1" }),
   };
   const ALL = Object.values(A);
 
@@ -353,6 +405,8 @@
   function emit(fromId, toId, opts = {}) {
     const from = A[fromId], to = A[toId];
     if (!from || !to) return null;
+    from.lastSeen = tick;
+    to.lastSeen = tick;
     const p = {
       from, to,
       amount: opts.amount ?? 0,
@@ -514,8 +568,10 @@
       }
     }
 
-    // body
+    // body — dispatch on shape
     if (a.shape === "hex") drawHexBody(a, balanceRatio);
+    else if (a.shape === "octagon") drawOctagonBody(a, balanceRatio);
+    else if (a.shape === "squircle") drawSquircleBody(a, balanceRatio);
     else drawCircleBody(a, balanceRatio);
 
     // HITL lock dot
@@ -553,7 +609,7 @@
   }
 
   function drawCircleBody(a, balanceRatio) {
-    const { x, y } = a.pos, r = a.radius;
+    const { x, y } = a.pos, r = a.radius * (a._hoverEase || 1);
     ctx.save();
     if (a.state === "passive") {
       const g = ctx.createRadialGradient(x - r*0.3, y - r*0.3, r*0.1, x, y, r);
@@ -576,8 +632,102 @@
     ctx.restore();
   }
 
+  function drawSquircleBody(a, balanceRatio) {
+    // Soft rounded square — the "human-operated agent" silhouette.
+    const { x, y } = a.pos, r = a.radius * (a._hoverEase || 1);
+    ctx.save();
+    const w = r * 1.8, h = r * 1.8, rr = r * 0.55;
+    const x0 = x - w / 2, y0 = y - h / 2;
+    if (a.state === "passive") {
+      const g = ctx.createLinearGradient(x0, y0, x0, y0 + h);
+      g.addColorStop(0, hsla(a.hue, 40, 70, 0.20));
+      g.addColorStop(1, hsla(a.hue, 40, 30, 0.06));
+      ctx.fillStyle = g;
+      roundedRectPath(ctx, x0, y0, w, h, rr);
+      ctx.fill();
+      ctx.strokeStyle = "rgba(231, 233, 238, 0.12)"; ctx.lineWidth = 1;
+      roundedRectPath(ctx, x0, y0, w, h, rr); ctx.stroke();
+    } else {
+      const g = ctx.createLinearGradient(x0, y0, x0, y0 + h);
+      g.addColorStop(0, hsla(a.hue, 90, 70, 0.85 * (0.35 + 0.65 * balanceRatio)));
+      g.addColorStop(0.6, hsla(a.hue, 80, 50, 0.55 * (0.4 + 0.6 * balanceRatio)));
+      g.addColorStop(1, hsla(a.hue, 60, 30, 0.85));
+      ctx.fillStyle = g;
+      roundedRectPath(ctx, x0, y0, w, h, rr); ctx.fill();
+      ctx.strokeStyle = walletColor(a.wallet);
+      ctx.lineWidth = 1.6;
+      roundedRectPath(ctx, x0, y0, w, h, rr); ctx.stroke();
+    }
+    // tiny "person" glyph — head + shoulders silhouette
+    ctx.fillStyle = "rgba(11, 13, 16, 0.55)";
+    ctx.beginPath(); ctx.arc(x, y - r * 0.18, r * 0.18, 0, Math.PI * 2); ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(x - r * 0.34, y + r * 0.32);
+    ctx.quadraticCurveTo(x, y + r * 0.06, x + r * 0.34, y + r * 0.32);
+    ctx.lineTo(x + r * 0.34, y + r * 0.42);
+    ctx.lineTo(x - r * 0.34, y + r * 0.42);
+    ctx.closePath(); ctx.fill();
+    ctx.restore();
+  }
+
+  function drawOctagonBody(a, balanceRatio) {
+    // Eight-sided — the "autonomous / bot" silhouette.
+    const { x, y } = a.pos, r = a.radius * (a._hoverEase || 1);
+    ctx.save();
+    octagonPath(ctx, x, y, r);
+    if (a.state === "passive") {
+      const g = ctx.createRadialGradient(x, y, r * 0.2, x, y, r);
+      g.addColorStop(0, hsla(a.hue, 40, 65, 0.22));
+      g.addColorStop(1, hsla(a.hue, 40, 30, 0.06));
+      ctx.fillStyle = g; ctx.fill();
+      ctx.strokeStyle = "rgba(231, 233, 238, 0.12)"; ctx.lineWidth = 1; ctx.stroke();
+    } else {
+      const g = ctx.createRadialGradient(x, y, 1, x, y, r);
+      g.addColorStop(0,  hsla(a.hue, 95, 70, 0.95 * (0.35 + 0.65 * balanceRatio)));
+      g.addColorStop(0.6, hsla(a.hue, 85, 50, 0.55 * (0.4 + 0.6 * balanceRatio)));
+      g.addColorStop(1,  hsla(a.hue, 60, 30, 0.85));
+      ctx.fillStyle = g; ctx.fill();
+      ctx.strokeStyle = walletColor(a.wallet);
+      ctx.lineWidth = a.wallet === "treasury" ? 2.2 : 1.6;
+      ctx.stroke();
+    }
+    // tiny circuit hint — two horizontal traces
+    ctx.strokeStyle = "rgba(11, 13, 16, 0.45)";
+    ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    ctx.moveTo(x - r * 0.4, y - r * 0.1); ctx.lineTo(x + r * 0.4, y - r * 0.1);
+    ctx.moveTo(x - r * 0.4, y + r * 0.16); ctx.lineTo(x + r * 0.4, y + r * 0.16);
+    ctx.stroke();
+    ctx.fillStyle = "rgba(11, 13, 16, 0.7)";
+    [-0.3, 0, 0.3].forEach(t => {
+      ctx.beginPath(); ctx.arc(x + r * t, y - r * 0.1, 1.3, 0, Math.PI*2); ctx.fill();
+      ctx.beginPath(); ctx.arc(x + r * t, y + r * 0.16, 1.3, 0, Math.PI*2); ctx.fill();
+    });
+    ctx.restore();
+  }
+
+  function roundedRectPath(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y,     x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x,     y + h, r);
+    ctx.arcTo(x,     y + h, x,     y,     r);
+    ctx.arcTo(x,     y,     x + w, y,     r);
+    ctx.closePath();
+  }
+  function octagonPath(ctx, cx, cy, r) {
+    ctx.beginPath();
+    for (let i = 0; i < 8; i++) {
+      const ang = -Math.PI / 8 + i * Math.PI / 4;
+      const px = cx + Math.cos(ang) * r;
+      const py = cy + Math.sin(ang) * r;
+      if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+  }
+
   function drawHexBody(a, balanceRatio) {
-    const { x, y } = a.pos, r = a.radius;
+    const { x, y } = a.pos, r = a.radius * (a._hoverEase || 1);
     ctx.save();
     ctx.beginPath();
     for (let i = 0; i < 6; i++) {
@@ -722,33 +872,49 @@
     if (!hoverId) { ttEl.classList.remove("show"); return; }
     const a = A[hoverId];
     const walletDesc = {
-      agentic:  "autonomous, auto-pays under cap",
+      agentic:  "autonomous · auto-pays under cap",
       hitl:     "human approves spend above threshold",
-      treasury: "rebalancer / fleet funder",
-      provider: "sells work, receives payments",
-      oracle:   "sells signed data, pay-per-query",
-      contract: "on-chain settlement (AgentEscrow.sol)",
+      treasury: "rebalancer · fleet funder",
+      provider: "sells work · receives payments",
+      oracle:   "sells signed data · pay-per-query",
+      contract: "on-chain settlement contract",
     }[a.wallet] || "";
+    const kindLabel = {
+      human: "human-operated",
+      bot:   "autonomous agent",
+      contract: "on-chain contract",
+    }[a.kind] || a.kind;
+    const kindGlyph = { human: "◐", bot: "⬢", contract: "⬡" }[a.kind] || "•";
     const wColor = walletColor(a.wallet);
+    const protoList = (a.protocols || []).map(p => `<span class="ttproto">${p}</span>`).join("");
+    const lastSeenLabel = a.lastSeen
+      ? `${Math.max(0, tick - a.lastSeen)} ticks ago`
+      : `idle`;
+
     ttEl.innerHTML = `
-      <div class="ttname">${a.name}</div>
+      <div class="ttname">${kindGlyph} ${a.name}</div>
       <div class="ttrole">${a.role}</div>
-      <span class="ttkind" style="color:${wColor};border-color:${wColor}">${a.wallet}</span>
-      <div style="color:var(--muted);font-size:10px;margin-bottom:4px">${walletDesc}</div>
+      <div class="ttrow">
+        <span class="ttkind" style="color:${wColor};border-color:${wColor}">${a.wallet}</span>
+        <span class="ttkind" style="color:var(--muted)">${kindLabel}</span>
+      </div>
+      <div class="ttdesc">${walletDesc}</div>
+      <div class="ttproto-row">${protoList || '<span class="ttproto muted">—</span>'}</div>
       <dl>
         <dt>balance</dt><dd>${a.balance.toFixed(2)} USDC</dd>
         <dt>daily cap</dt><dd>${a.dailyCap.toFixed(0)} USDC</dd>
         <dt>spent</dt><dd>${a.spent.toFixed(2)} USDC</dd>
         <dt>state</dt><dd>${a.state}</dd>
+        <dt>sig alg</dt><dd>${a.sigAlg}</dd>
+        <dt>last seen</dt><dd>${lastSeenLabel}</dd>
         <dt>sig hue</dt><dd>h${a.hue}°</dd>
       </dl>
     `;
-    // place near cursor, flip when near right edge
     const pad = 14;
     let tx = clientX + pad, ty = clientY + pad;
     const rect = ttEl.getBoundingClientRect();
-    if (tx + 220 > window.innerWidth) tx = clientX - 220 - pad;
-    if (ty + 200 > window.innerHeight) ty = clientY - rect.height - pad;
+    if (tx + 240 > window.innerWidth) tx = clientX - 240 - pad;
+    if (ty + rect.height > window.innerHeight) ty = clientY - rect.height - pad;
     ttEl.style.left = tx + "px";
     ttEl.style.top  = ty + "px";
     ttEl.classList.add("show");
@@ -1366,13 +1532,13 @@
   // adjacent. This scene illustrates the data-flow seams.
   // We extend the agent registry with repo "nodes" rendered with a contract
   // hex shape but distinct hues + per-repo roles.
-  A.swb       = makeAgent({ id: "swb",       name: "switchboard", role: "agent payments substrate", wallet: "contract", hue: 215, radius: 42, shape: "hex" });
-  A.zap_repo  = makeAgent({ id: "zap_repo",  name: "zap",         role: "zero-alloc binary wire",   wallet: "contract", hue: 285, radius: 32, shape: "hex" });
-  A.arka_repo = makeAgent({ id: "arka_repo", name: "arka",        role: "Rust agent SDK",           wallet: "contract", hue:  25, radius: 32, shape: "hex" });
-  A.scout_repo= makeAgent({ id: "scout_repo",name: "scout",       role: "wallet intel",             wallet: "contract", hue: 165, radius: 32, shape: "hex" });
-  A.gas_repo  = makeAgent({ id: "gas_repo",  name: "gas-oracle",  role: "L2 gas forecasts",         wallet: "contract", hue:  55, radius: 32, shape: "hex" });
-  A.x402_repo = makeAgent({ id: "x402_repo", name: "x402",        role: "upstream HTTP-402 spec",   wallet: "contract", hue: 195, radius: 32, shape: "hex" });
-  A.aeo_repo  = makeAgent({ id: "aeo_repo",  name: "AgentEscrow", role: "on-chain settlement",      wallet: "contract", hue: 250, radius: 30, shape: "hex" });
+  A.swb       = makeAgent({ id: "swb",       name: "switchboard", role: "agent payments substrate", kind: "contract", wallet: "contract", hue: 215, radius: 42, protocols: ["x402","MPP","ZAP","escrow"], sigAlg: "policy: hybrid+ml-dsa-65" });
+  A.zap_repo  = makeAgent({ id: "zap_repo",  name: "zap",         role: "zero-alloc binary wire",   kind: "contract", wallet: "contract", hue: 285, radius: 32, protocols: ["ZAP"], sigAlg: "n/a (wire format)" });
+  A.arka_repo = makeAgent({ id: "arka_repo", name: "arka",        role: "Rust agent SDK",           kind: "contract", wallet: "contract", hue:  25, radius: 32, protocols: ["x402","MPP"], sigAlg: "consumes switchboard" });
+  A.scout_repo= makeAgent({ id: "scout_repo",name: "scout",       role: "wallet intel",             kind: "contract", wallet: "contract", hue: 165, radius: 32, protocols: ["intel"], sigAlg: "ml-dsa-65" });
+  A.gas_repo  = makeAgent({ id: "gas_repo",  name: "gas-oracle",  role: "L2 gas forecasts",         kind: "contract", wallet: "contract", hue:  55, radius: 32, protocols: ["signed-data"], sigAlg: "ml-dsa-65" });
+  A.x402_repo = makeAgent({ id: "x402_repo", name: "x402",        role: "upstream HTTP-402 spec",   kind: "contract", wallet: "contract", hue: 195, radius: 32, protocols: ["x402"], sigAlg: "spec — no sig" });
+  A.aeo_repo  = makeAgent({ id: "aeo_repo",  name: "AgentEscrow", role: "on-chain settlement",      kind: "contract", wallet: "contract", hue: 250, radius: 30, protocols: ["escrow"], sigAlg: "ecdsa-secp256k1" });
 
   SCENES.stack = {
     id: "stack",
@@ -1629,19 +1795,20 @@
     id: "cafe",
     name: "Café walk-up",
     short: "11",
-    desc: "Smallest possible flow. <strong>Patty</strong> walks past <strong>Aroma</strong>'s shop, her agent does a proximity handshake, picks a latte off the signed menu, pays 4.50 USDC, takes the cup.",
+    desc: "Smallest possible flow. <strong>Patty</strong> walks up to <strong>Abhi</strong>'s espresso bar. The shop's POS agent (Aroma) does a proximity handshake with Patty, picks a latte off the signed menu, pays 4.50 USDC, takes the cup. Abhi is the human; Aroma is the bot surface he runs.",
     enter() {
-      setVisible(["bob", "cafe"]);
+      setVisible(["bob", "eli", "cafe"]);
       A.bob.balance = 20; A.bob.spent = 0;
-      A.cafe.balance = 0;
+      A.cafe.balance = 0; A.eli.balance = 0;
       this.layout();
       this.phase = 0; this.cool = 50;
-      setCaption("step 1 / 5", "<strong>Patty</strong> approaches <strong>Aroma</strong>. Bluetooth-range handshake announces both agents to each other.");
-      log(`<span class="info">cafe</span> scene loaded`);
+      setCaption("step 1 / 5", "<strong>Patty</strong> approaches <strong>Abhi</strong>'s café. Aroma POS handshakes with Patty's agent; Abhi watches from behind the counter.");
+      log(`<span class="info">cafe</span> scene loaded · Abhi's espresso bar`);
     },
     layout() {
-      A.bob.pos  = { x: W * 0.25, y: H * 0.55 };
-      A.cafe.pos = { x: W * 0.72, y: H * 0.5  };
+      A.bob.pos  = { x: W * 0.22, y: H * 0.6 };
+      A.cafe.pos = { x: W * 0.66, y: H * 0.55 };
+      A.eli.pos  = { x: W * 0.82, y: H * 0.4  };
     },
     drawUnderlay(ctx, W, H) {
       // counter rectangle behind the cafe
@@ -1657,7 +1824,7 @@
       ctx.strokeRect(x, y, w, h);
       ctx.fillStyle = "rgba(231, 233, 238, 0.5)";
       ctx.font = "10px ui-monospace, Menlo, monospace";
-      ctx.fillText("AROMA  ·  espresso bar", x + 10, y + 16);
+      ctx.fillText("ABHI'S  ·  espresso bar", x + 10, y + 16);
       ctx.restore();
     },
     tick(t) {
@@ -1702,23 +1869,24 @@
     id: "delivery",
     name: "Food delivery",
     short: "12",
-    desc: "Three-party flow. <strong>Patty</strong> orders from <strong>Spice Hub</strong>; <strong>Kiran</strong> takes the delivery slot. Escrow splits the payout: food to the restaurant, tip to the rider. Rider's position animates along the route.",
+    desc: "Three-party flow. <strong>Patty</strong> orders from <strong>Tridib</strong>'s restaurant (Spice Hub); <strong>Kiran</strong> (rider) takes the delivery slot. Escrow splits the payout: food to Tridib on pickup, tip to Kiran on delivery confirm.",
     enter() {
-      setVisible(["bob", "rest", "rider", "escrow"]);
-      A.bob.balance = 25; A.rest.balance = 0; A.rider.balance = 0;
+      setVisible(["bob", "gus", "rest", "rider", "escrow"]);
+      A.bob.balance = 25; A.rest.balance = 0; A.rider.balance = 0; A.gus.balance = 0;
       A.escrow.balance = 0;
       this.layout();
       this.phase = 0; this.cool = 60;
       this.tRide = 0;
       A.rider._visible = false;
-      setCaption("step 1 / 7", "<strong>Patty</strong> orders from <strong>Spice Hub</strong>: ₹420 of biryani. Restaurant confirms.");
-      log(`<span class="info">delivery</span> scene loaded · multi-party escrow`);
+      setCaption("step 1 / 7", "<strong>Patty</strong> orders from <strong>Tridib</strong>'s Spice Hub: 5.00 USDC of biryani.");
+      log(`<span class="info">delivery</span> scene loaded · Tridib's kitchen, Kiran riding`);
     },
     layout() {
       this.home = { x: W * 0.82, y: H * 0.68 };
       this.restaurant = { x: W * 0.18, y: H * 0.32 };
       A.bob.pos  = { ...this.home };
       A.rest.pos = { ...this.restaurant };
+      A.gus.pos  = { x: W * 0.10, y: H * 0.20 };          // Tridib next to his kitchen
       A.escrow.pos = { x: W * 0.5, y: H * 0.85 };
       A.rider.pos = { x: W * 0.1, y: H * 0.5 };
     },
@@ -1756,11 +1924,11 @@
             y: lerp(H * 0.5, this.restaurant.y + 6,  Math.min(1, this.tRide)),
           };
           if (this.tRide >= 1) {
-            log(`Pickup complete · 80% (4.00 USDC) released to Spice Hub`);
+            log(`Pickup complete · 80% (4.00 USDC) released to Tridib`);
             emit("escrow", "rest", { kind: "proof", label: "food paid 4.00", speed: 0.022,
               onArrive: () => { A.escrow.balance -= 4; A.rest.balance += 4; } });
             this.phase = 4; this.cool = 60; this.tRide = 0;
-            setCaption("step 5 / 7", "Pickup confirmed → 80% released to <strong>Spice Hub</strong>. Kiran rolls toward Patty.");
+            setCaption("step 5 / 7", "Pickup confirmed → 80% released to <strong>Tridib</strong>. Kiran rolls toward Patty.");
           }
           break;
         }
@@ -1801,21 +1969,21 @@
     id: "split",
     name: "Split bill",
     short: "13",
-    desc: "Four friends, one tab. Each agent computes its share against the signed line-items and pays the merchant simultaneously. The merchant only sees one settlement event: a complete bill. Drop-in for fintech apps that today require a single payer + chase-up later.",
+    desc: "Four friends — <strong>Patty</strong>, <strong>Abhi</strong>, <strong>Tridib</strong>, and <strong>Sara</strong> — sit down at the Bistro. Each agent computes its share against the merchant's signed line-items and pays simultaneously. The merchant sees one settlement event: a complete bill. Drop-in for fintech apps that today require a single payer + chase-up later.",
     enter() {
-      setVisible(["bob", "alice", "iris", "juno", "merchant"]);
-      A.bob.balance = 30; A.alice.balance = 30; A.iris.balance = 30; A.juno.balance = 30;
+      setVisible(["bob", "eli", "gus", "sara", "merchant"]);
+      A.bob.balance = 30; A.eli.balance = 30; A.gus.balance = 30; A.sara.balance = 30;
       A.merchant.balance = 0;
       this.total = 48.00;
       this.share = this.total / 4;
       this.layout();
       this.phase = 0; this.cool = 60;
       setCaption("step 1 / 3", `Bill: <code>${this.total.toFixed(2)} USDC</code>. Four agents see the signed itemized receipt and compute their share (${this.share.toFixed(2)} each).`);
-      log(`<span class="info">split</span> scene loaded · bill 48.00 USDC / 4 friends`);
+      log(`<span class="info">split</span> scene loaded · bill 48.00 USDC · Patty + Abhi + Tridib + Sara`);
     },
     layout() {
       A.merchant.pos = { x: W * 0.5, y: H * 0.5 };
-      ring(["bob", "alice", "iris", "juno"], W * 0.5, H * 0.5, Math.min(W, H) * 0.3);
+      ring(["bob", "eli", "gus", "sara"], W * 0.5, H * 0.5, Math.min(W, H) * 0.3);
     },
     drawUnderlay(ctx, W, H) {
       // round "table" behind the merchant
@@ -1836,13 +2004,13 @@
       if (this.cool > 0) { this.cool--; return; }
       switch (this.phase) {
         case 0:
-          ["bob", "alice", "iris", "juno"].forEach(id => emit("merchant", id, { kind: "data", label: "receipt", speed: 0.024 }));
-          log(`Tridib's sends signed line-items to all four agents`);
+          ["bob", "eli", "gus", "sara"].forEach(id => emit("merchant", id, { kind: "data", label: "receipt", speed: 0.024 }));
+          log(`Bistro sends signed line-items to all four agents`);
           this.phase = 1; this.cool = 70;
           setCaption("step 2 / 3", "Each agent verifies the merchant's signature and the line-items it's accountable for, then fires its share.");
           break;
         case 1:
-          ["bob", "alice", "iris", "juno"].forEach((id, i) => {
+          ["bob", "eli", "gus", "sara"].forEach((id, i) => {
             setTimeout(() => {
               emit(id, "merchant", { kind: "offer", label: this.share.toFixed(2),
                 amount: this.share, speed: 0.024,
@@ -1853,14 +2021,14 @@
                     jobs++; jobsEl.textContent = jobs;
                   }
                 }});
-              log(`${A[id].name} → Tridib's: ${this.share.toFixed(2)} USDC`);
+              log(`${A[id].name} → Bistro: ${this.share.toFixed(2)} USDC`);
             }, i * 140);
           });
           this.phase = 2; this.cool = 200;
           setCaption("step 3 / 3", "Merchant receives all four packets within one settlement window. No chasing, no Venmo IOU thread.");
           break;
         case 2:
-          A.bob.balance = 30; A.alice.balance = 30; A.iris.balance = 30; A.juno.balance = 30;
+          A.bob.balance = 30; A.eli.balance = 30; A.gus.balance = 30; A.sara.balance = 30;
           A.merchant.balance = 0;
           this.phase = 0; this.cool = 80;
           break;
@@ -1868,10 +2036,172 @@
     },
   };
 
+  // — Scene 14: Native ETH escrow (Patty ↔ Abhi) ——————————————————————————
+  // Plain ETH msg.value path through AgentEscrow.sol — no ERC-20 approve,
+  // no token contract, no wrapped assets. Works on any EVM chain out of
+  // the box. The cheapest, most universal A2A settlement primitive.
+  SCENES.ethEscrow = {
+    id: "ethEscrow",
+    name: "Native ETH escrow",
+    short: "14",
+    desc: "<strong>Patty</strong> hires <strong>Abhi</strong> for a one-shot inference job priced in <strong>ETH</strong>. No ERC-20 dance — funds lock via <code>createPayment{value: 0.05 ether}(...)</code> in <code>AgentEscrow.sol</code>. Abhi delivers, Patty confirms, escrow releases. Universal across EVM chains.",
+    enter() {
+      setVisible(["bob", "eli", "escrow"]);
+      A.bob.balance = 0.50; A.bob.spent = 0; A.bob.dailyCap = 1.0;       // ETH this scene
+      A.eli.balance = 0.00;
+      A.escrow.balance = 0;
+      this.layout();
+      this.phase = 0; this.cool = 60;
+      this.gasEth = 0.0008;
+      setCaption("step 1 / 6", "<strong>Patty</strong> commissions <strong>Abhi</strong> for a custom inference job. Quote: <code>0.05 ETH</code>. No tokens, no wrappers.");
+      log(`<span class="info">eth-escrow</span> scene loaded · 0.05 ETH job`);
+    },
+    layout() {
+      A.bob.pos    = { x: W * 0.20, y: H * 0.5 };
+      A.eli.pos    = { x: W * 0.80, y: H * 0.5 };
+      A.escrow.pos = { x: W * 0.50, y: H * 0.78 };
+    },
+    drawOverlay(ctx, W, H) {
+      // ETH plaque next to the escrow
+      const x = A.escrow.pos.x, y = A.escrow.pos.y + A.escrow.radius + 22;
+      ctx.fillStyle = "rgba(231, 233, 238, 0.85)";
+      ctx.font = "11px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      const locked = A.escrow.balance.toFixed(3);
+      ctx.fillText(`locked: ${locked} ETH`, x, y);
+      ctx.fillStyle = "rgba(138, 147, 163, 0.85)";
+      ctx.font = "10px ui-monospace, Menlo, monospace";
+      ctx.fillText(`createPayment{value: msg.value}`, x, y + 14);
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      switch (this.phase) {
+        case 0:
+          emit("eli", "bob", { kind: "data", label: "signed quote · 0.05 ETH", speed: 0.022 });
+          log(`Abhi → Patty: PQ-signed quote · 0.05 ETH`);
+          this.phase = 1; this.cool = 70;
+          setCaption("step 2 / 6", "Abhi returns a PQ-signed quote. Patty's agent verifies, accepts, prepares the on-chain tx.");
+          break;
+        case 1:
+          // Patty's wallet pays gas + sends value into escrow
+          emit("bob", "escrow", { kind: "offer", label: "createPayment 0.05 ETH", amount: 0.05, speed: 0.018,
+            onArrive: () => {
+              A.bob.balance -= (0.05 + this.gasEth);
+              A.escrow.balance += 0.05;
+            }});
+          log(`Patty → Escrow: <code>createPayment(reqId, abhi, 100, 10){value: 0.05 ETH}</code>`);
+          this.phase = 2; this.cool = 90;
+          setCaption("step 3 / 6", `<strong>0.05 ETH</strong> locks in escrow. <code>msg.value</code> sits in <code>payments[reqId].amount</code>. Patty also paid ~${this.gasEth.toFixed(4)} ETH gas.`);
+          break;
+        case 2:
+          emit("eli", "bob", { kind: "data", label: "deliverable", speed: 0.020 });
+          log(`Abhi → Patty: deliverable (inference result + receipt)`);
+          this.phase = 3; this.cool = 80;
+          setCaption("step 4 / 6", "Abhi performs the work off-chain, delivers the result with a PQ-signed receipt. Patty verifies output and signature.");
+          break;
+        case 3:
+          emit("bob", "escrow", { kind: "request", label: "confirmPayment", speed: 0.022,
+            onArrive: () => {
+              emit("escrow", "eli", { kind: "proof", label: "released 0.05 ETH", speed: 0.022,
+                onArrive: () => {
+                  A.escrow.balance -= 0.05; A.eli.balance += 0.05;
+                  jobs++; jobsEl.textContent = jobs;
+                }});
+            }});
+          log(`Patty → Escrow: <code>confirmPayment(reqId)</code> · funds release to Abhi`);
+          this.phase = 4; this.cool = 130;
+          setCaption("step 5 / 6", "Patty calls <code>confirmPayment()</code>. Escrow's internal accounting transitions <code>State.Locked → State.Released</code> and <code>.call{value: amount}(\"\")</code> forwards ETH to Abhi.");
+          break;
+        case 4:
+          setCaption("step 6 / 6", `Done. Abhi's wallet credited <code>0.05 ETH</code> directly — no token approval, no wrap, no relayer. Same primitive on Ethereum, Base, Lux, Arbitrum.`);
+          log(`<span class="ok">handover complete</span> · Abhi balance ${A.eli.balance.toFixed(3)} ETH`);
+          this.phase = 5; this.cool = 220;
+          break;
+        case 5:
+          A.bob.balance = 0.50; A.eli.balance = 0;
+          A.escrow.balance = 0;
+          this.phase = 0; this.cool = 80;
+          break;
+      }
+    },
+  };
+
+  // — Scene 15: Subscription with auto-cap ————————————————————————————————
+  // Patty subscribes to Abhi's API. Monthly renewal hits inside her
+  // standing cap; cancellation = revoke the cap. Pattern composes from
+  // primitives the protocol already has: x402 + per-period gas budget.
+  SCENES.subscribe = {
+    id: "subscribe",
+    name: "Subscription",
+    short: "15",
+    desc: "<strong>Patty</strong> subscribes to <strong>Abhi</strong>'s API at 2 USDC/period under a 10 USDC/month cap. Renewal hits automatically while inside the cap, fails loudly outside. Cancel = revoke the cap; no merchant trust, no zombie charges.",
+    enter() {
+      setVisible(["bob", "eli"]);
+      A.bob.balance = 20; A.bob.spent = 0; A.bob.dailyCap = 10;
+      A.eli.balance = 0;
+      this.layout();
+      this.phase = 0; this.cool = 40;
+      this.period = 0; this.maxPeriods = 6;
+      this.fee = 2.0;
+      setCaption("step 1 / 3", "Subscription opens. Cap: 10 USDC / month. Fee: 2 USDC / period. Patty's agent will renew autonomously while inside the cap.");
+      log(`<span class="info">subscribe</span> scene loaded · cap 10 USDC / 5 periods`);
+    },
+    layout() {
+      A.bob.pos = { x: W * 0.28, y: H * 0.5 };
+      A.eli.pos = { x: W * 0.72, y: H * 0.5 };
+    },
+    drawOverlay(ctx, W, H) {
+      // bar between Patty + Abhi showing cap usage
+      const x = (A.bob.pos.x + A.eli.pos.x) / 2, y = (A.bob.pos.y + A.eli.pos.y) / 2 - 90;
+      const w = 240, h = 22;
+      const pct = Math.min(1, A.bob.spent / Math.max(0.01, A.bob.dailyCap));
+      ctx.fillStyle = "rgba(13, 16, 21, 0.85)";
+      ctx.strokeStyle = "rgba(35, 39, 47, 0.9)";
+      ctx.fillRect(x - w/2, y, w, h);
+      ctx.strokeRect(x - w/2, y, w, h);
+      ctx.fillStyle = pct < 0.85 ? "rgba(125, 211, 252, 0.7)" : "rgba(248, 113, 113, 0.85)";
+      ctx.fillRect(x - w/2 + 2, y + 2, (w - 4) * pct, h - 4);
+      ctx.fillStyle = "rgba(231, 233, 238, 0.85)";
+      ctx.font = "11px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(`monthly cap ${A.bob.spent.toFixed(2)} / ${A.bob.dailyCap.toFixed(0)} USDC · period ${this.period} / ${this.maxPeriods}`, x, y - 6);
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      if (this.period >= this.maxPeriods) {
+        if (!this.cancelled) {
+          this.cancelled = true;
+          log(`<span class="warn">subscription cancelled</span> · cap revoked`);
+          setCaption("step 3 / 3", "Patty's agent revokes the cap. No further charges possible. Demonstrates the cancel path: no merchant cooperation needed.");
+        }
+        if (t % 240 === 0) { A.bob.balance = 20; A.bob.spent = 0; A.eli.balance = 0;
+                             this.period = 0; this.cancelled = false; }
+        return;
+      }
+      if (A.bob.spent + this.fee > A.bob.dailyCap) {
+        log(`<span class="hot">renewal blocked</span> · would exceed monthly cap`);
+        setCaption("step 3 / 3", "Renewal would breach Patty's monthly cap → blocked at the wallet layer, never reaches Abhi.");
+        this.period = this.maxPeriods;
+        this.cool = 60;
+        return;
+      }
+      emit("bob", "eli", { kind: "stream", label: `${this.fee.toFixed(2)} USDC`, amount: this.fee, speed: 0.026,
+        onArrive: () => {
+          A.bob.balance -= this.fee; A.bob.spent += this.fee;
+          A.eli.balance += this.fee;
+          jobs++; jobsEl.textContent = jobs;
+        }});
+      log(`renewal #${this.period + 1} · 2.00 USDC → Abhi`);
+      if (this.period === 0) setCaption("step 2 / 3", "First period charges immediately. Subsequent renewals hit on schedule, gated by the cap.");
+      this.period++;
+      this.cool = 90;
+    },
+  };
+
   // ─── scene registry & switcher ────────────────────────────────────────────
   const SCENE_ORDER = [
     "x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle", "pq", "stack",
-    "taxi", "cafe", "delivery", "split",
+    "taxi", "cafe", "delivery", "split", "ethEscrow", "subscribe",
   ];
 
   function selectScene(id, force) {
@@ -1891,15 +2221,43 @@
     log(`<span class="seg">— scene switched to <strong>${currentScene.name}</strong> —</span>`);
   }
 
+  // Group scene-bar by category for readability.
+  // Group A: protocol primitives. Group B: real-world use cases.
+  // Group C: meta (PQ proposal, stack).
+  const SCENE_GROUPS = [
+    { label: "primitives", ids: ["x402","escrow","stream","auction","hitl","fanout","oracle"] },
+    { label: "use cases",  ids: ["taxi","cafe","delivery","split","ethEscrow","subscribe"] },
+    { label: "meta",       ids: ["pq","stack"] },
+  ];
+
   const sceneBar = document.getElementById("sceneBar");
-  SCENE_ORDER.forEach(id => {
-    const s = SCENES[id];
-    const b = document.createElement("button");
-    b.dataset.scene = id;
-    b.innerHTML = `<span class="num">${s.short}</span>${s.name}`;
-    b.addEventListener("click", () => selectScene(id));
-    sceneBar.appendChild(b);
+  SCENE_GROUPS.forEach((group, gi) => {
+    if (gi > 0) {
+      const sep = document.createElement("span"); sep.className = "sep"; sceneBar.appendChild(sep);
+    }
+    group.ids.forEach(id => {
+      const s = SCENES[id];
+      if (!s) return;
+      const b = document.createElement("button");
+      b.dataset.scene = id;
+      b.innerHTML = `<span class="num">${s.short}</span>${s.name}`;
+      b.title = s.name + " — " + group.label;
+      b.addEventListener("click", () => selectScene(id));
+      sceneBar.appendChild(b);
+    });
   });
+
+  // "Add yours" CTA — invites developers to contribute a scene.
+  {
+    const sep = document.createElement("span"); sep.className = "sep"; sceneBar.appendChild(sep);
+    const b = document.createElement("a");
+    b.href = "https://github.com/kcolbchain/switchboard/blob/main/web/SCENES.md";
+    b.target = "_blank"; b.rel = "noopener";
+    b.className = "add-scene";
+    b.innerHTML = `<span class="plus">＋</span>Add your scene`;
+    b.title = "Open the scene template — fork, drop in, send a PR";
+    sceneBar.appendChild(b);
+  }
 
   // ─── split-flap "switchboard" title ───────────────────────────────────────
   const SB_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_/";

--- a/web/agents-demo.html
+++ b/web/agents-demo.html
@@ -266,6 +266,12 @@
       <div class="empty">hover an agent to inspect</div>
     </div>
 
+    <div id="ctlPanel" class="ctl-panel" style="display:none">
+      <h2>Simulation controls</h2>
+      <div id="ctlList" class="ctl-list"></div>
+      <button id="ctlReset" class="ctl-btn">Restart scene</button>
+    </div>
+
     <h2>Shapes</h2>
     <div class="legend">
       <div><span class="shape sq"></span><span class="row-key">human</span> — Patty, Abhi, Tridib</div>
@@ -328,6 +334,7 @@
   let DPR = window.devicePixelRatio || 1;
   let W = 0, H = 0;
   let mouse = { x: -1, y: -1, shift: false };
+  let lastClient = { x: -1, y: -1 };       // last cursor position in client coords (for live tooltip)
   let hoverId = null;
   let paused = false;
   let tick = 0;
@@ -427,6 +434,7 @@
     const r = cvs.getBoundingClientRect();
     mouse.x = e.clientX - r.left;
     mouse.y = e.clientY - r.top;
+    lastClient.x = e.clientX; lastClient.y = e.clientY;
     const prevHover = hoverId;
     hoverId = pickAgent(mouse.x, mouse.y);
     if (hoverId && hoverId !== prevHover) {
@@ -436,10 +444,11 @@
       a._ripples.push({ t: 0, r: a.radius });
     }
     renderInfo();
-    renderTooltip(e.clientX, e.clientY);
+    renderTooltip(lastClient.x, lastClient.y);
   });
   cvs.addEventListener("mouseleave", () => {
-    hoverId = null; renderInfo();
+    hoverId = null; lastClient.x = -1; lastClient.y = -1;
+    renderInfo();
     ttEl.classList.remove("show");
   });
   cvs.addEventListener("click", () => {
@@ -840,6 +849,17 @@
     if (!paused && currentScene && currentScene.tick) currentScene.tick(sceneTick);
 
     draw();
+
+    // Tooltip + inspector live-refresh while a hover is active. Without this,
+    // a tooltip pinned on Patty wouldn't show her balance dropping after a
+    // packet arrives — the user would have to wiggle the mouse to refresh.
+    // No throttle — innerHTML update of a small card is cheap and the user
+    // wants instant feedback.
+    if (hoverId) {
+      renderInfo();
+      if (lastClient.x >= 0) renderTooltip(lastClient.x, lastClient.y);
+    }
+
     requestAnimationFrame(step);
   }
 

--- a/web/agents-demo.html
+++ b/web/agents-demo.html
@@ -14,15 +14,28 @@
     --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   }
   * { box-sizing: border-box; }
-  html, body { margin: 0; background: var(--bg); color: var(--fg);
+  html, body { margin: 0; background:
+    radial-gradient(1200px 800px at 20% 0%, #11161d 0%, #0b0d10 60%),
+    radial-gradient(900px 600px at 100% 100%, #131922 0%, #0b0d10 60%);
+    background-attachment: fixed;
+    color: var(--fg);
     font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
     overflow: hidden; }
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
 
-  header { padding: 12px 24px; border-bottom: 1px solid var(--border);
+  /* Translucent glass on every floating chrome surface */
+  .glass { background: rgba(15, 18, 22, 0.55);
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    border: 1px solid rgba(255, 255, 255, 0.06); }
+
+  header { padding: 12px 24px; border-bottom: 1px solid rgba(255, 255, 255, 0.05);
     display: flex; justify-content: space-between; align-items: center; gap: 12px;
-    flex-wrap: wrap; }
+    flex-wrap: wrap;
+    background: rgba(13, 16, 21, 0.55);
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%); }
   header h1 { margin: 0; font-size: 14px; font-weight: 500; color: var(--muted);
     letter-spacing: 0.02em; display: flex; align-items: center; gap: 10px; }
   header .crumbs { color: var(--muted-2); font-size: 11px; }
@@ -52,21 +65,37 @@
   .sb-char.scrambling::before { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
   .sb-tag { color: var(--muted); font-weight: 400; font-size: 12px; }
 
-  .scene-bar { display: flex; gap: 4px; padding: 8px 24px; border-bottom: 1px solid var(--border);
-    background: var(--panel-2); overflow-x: auto; }
-  .scene-bar button { background: transparent; color: var(--muted); border: 1px solid transparent;
-    padding: 5px 11px; border-radius: 6px; cursor: pointer;
-    font: inherit; font-size: 12px; white-space: nowrap; }
-  .scene-bar button:hover { color: var(--fg); }
-  .scene-bar button.active { background: var(--panel); color: var(--fg); border-color: var(--border); }
-  .scene-bar button .num { color: var(--muted-2); font-family: var(--mono); margin-right: 6px; }
+  .scene-bar { display: flex; gap: 6px; padding: 8px 18px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(13, 16, 21, 0.55);
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    overflow-x: auto; align-items: center; }
+  .scene-bar::-webkit-scrollbar { height: 0; }
+  .scene-bar button { background: rgba(255, 255, 255, 0.02); color: var(--muted);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    padding: 5px 11px; border-radius: 999px; cursor: pointer;
+    font: inherit; font-size: 12px; white-space: nowrap;
+    display: inline-flex; align-items: center; gap: 6px;
+    transition: color 0.15s, background 0.15s, border-color 0.15s; }
+  .scene-bar button:hover { color: var(--fg); border-color: rgba(255, 255, 255, 0.12); }
+  .scene-bar button.active { background: rgba(96, 165, 250, 0.12);
+    color: var(--fg); border-color: rgba(96, 165, 250, 0.5); }
+  .scene-bar button .num { color: var(--muted-2); font-family: var(--mono); font-size: 11px; }
+  .scene-bar .sep { width: 1px; height: 16px; background: rgba(255, 255, 255, 0.08); margin: 0 2px; }
 
-  .layout { display: grid; grid-template-columns: 240px 1fr 300px;
-    height: calc(100vh - 95px); }
+  .layout { display: grid; grid-template-columns: 250px 1fr 300px;
+    height: calc(100vh - 95px); gap: 0; }
 
-  aside { background: var(--panel-2); padding: 14px 16px; overflow-y: auto;
-    border-right: 1px solid var(--border); }
-  aside.right { border-right: none; border-left: 1px solid var(--border); }
+  aside { padding: 16px 16px 18px 16px; overflow-y: auto;
+    background: rgba(15, 18, 22, 0.55);
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    border-right: 1px solid rgba(255, 255, 255, 0.04); }
+  aside.right { border-right: none; border-left: 1px solid rgba(255, 255, 255, 0.04); }
+  aside::-webkit-scrollbar { width: 6px; }
+  aside::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.08); border-radius: 3px; }
+  aside::-webkit-scrollbar-track { background: transparent; }
   aside h2 { font-size: 10px; color: var(--muted); text-transform: uppercase;
     letter-spacing: 0.1em; margin: 0 0 8px 0; font-weight: 500; }
   aside h2:not(:first-child) { margin-top: 16px; }
@@ -109,22 +138,33 @@
   .log .info { color: var(--info); }
   .log .seg { color: var(--muted); }
 
-  .stage { position: relative; overflow: hidden; background: var(--bg); }
-  canvas { display: block; width: 100%; height: 100%; cursor: crosshair; }
+  .stage { position: relative; overflow: hidden; background: transparent; }
+  .stage::after {                                /* inner boundary frame */
+    content: ""; position: absolute; inset: 12px; pointer-events: none;
+    border: 1px solid rgba(255, 255, 255, 0.05); border-radius: 12px;
+    box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.35); }
+  canvas { display: block; width: 100%; height: 100%; cursor: crosshair;
+    position: relative; z-index: 1; }
 
-  .stats { position: absolute; top: 10px; left: 12px;
-    background: rgba(13, 16, 21, 0.85); border: 1px solid var(--border);
-    border-radius: 6px; padding: 6px 10px; font-family: var(--mono); font-size: 10px;
-    display: flex; gap: 14px; }
+  .stats { position: absolute; top: 18px; left: 20px; z-index: 2;
+    background: rgba(13, 16, 21, 0.6);
+    backdrop-filter: blur(12px) saturate(140%);
+    -webkit-backdrop-filter: blur(12px) saturate(140%);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 999px; padding: 6px 14px; font-family: var(--mono); font-size: 10px;
+    display: flex; gap: 14px; align-items: center; }
   .stats .label { color: var(--muted-2); margin-right: 4px; }
   .stats .val { color: var(--fg); }
   .stats .val.ok { color: var(--ok); }
   .stats .val.warn { color: var(--warn); }
 
-  .caption { position: absolute; bottom: 10px; left: 12px; right: 12px;
-    background: rgba(13, 16, 21, 0.86); border: 1px solid var(--border);
-    border-radius: 6px; padding: 10px 14px; font-size: 11px; color: var(--muted);
-    line-height: 1.55; max-width: 720px; margin: 0 auto; }
+  .caption { position: absolute; bottom: 18px; left: 20px; right: 20px; z-index: 2;
+    background: rgba(13, 16, 21, 0.6);
+    backdrop-filter: blur(12px) saturate(140%);
+    -webkit-backdrop-filter: blur(12px) saturate(140%);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 10px; padding: 11px 16px; font-size: 11px; color: var(--muted);
+    line-height: 1.55; max-width: 760px; margin: 0 auto; }
   .caption .step { color: var(--info); font-family: var(--mono); font-size: 10px;
     margin-right: 8px; }
   .caption code { font-family: var(--mono); color: var(--fg);
@@ -296,6 +336,14 @@
     iris:   makeAgent({ id: "iris",    name: "Iris",    role: "buyer",             wallet: "agentic",  hue: 180, balance: 6,    dailyCap: 12 }),
     juno:   makeAgent({ id: "juno",    name: "Juno",    role: "buyer",             wallet: "agentic",  hue:  90, balance: 5,    dailyCap: 10 }),
     escrow: makeAgent({ id: "escrow",  name: "Escrow",  role: "AgentEscrow.sol",   wallet: "contract", hue: 220, balance: 0, dailyCap: 999, radius: 30, shape: "hex" }),
+
+    // ── service agents for real-world use-case scenes ──
+    driver:  makeAgent({ id: "driver",  name: "Sai",      role: "taxi driver",         wallet: "provider", hue: 180, balance: 0,  dailyCap: 200, radius: 32 }),
+    dispatch:makeAgent({ id: "dispatch",name: "Dispatch", role: "ride-share matcher",  wallet: "contract", hue: 215, balance: 0,  dailyCap: 999, radius: 28, shape: "hex" }),
+    cafe:    makeAgent({ id: "cafe",    name: "Aroma",    role: "café POS",            wallet: "provider", hue:  28, balance: 0,  dailyCap: 200, radius: 34 }),
+    rest:    makeAgent({ id: "rest",    name: "Spice Hub",role: "restaurant",          wallet: "provider", hue:   8, balance: 0,  dailyCap: 200, radius: 34 }),
+    rider:   makeAgent({ id: "rider",   name: "Kiran",    role: "delivery rider",      wallet: "provider", hue: 115, balance: 0,  dailyCap: 200, radius: 30 }),
+    merchant:makeAgent({ id: "merchant",name: "Tridib's", role: "merchant (bill)",     wallet: "provider", hue:  60, balance: 0,  dailyCap: 999, radius: 36 }),
   };
   const ALL = Object.values(A);
 
@@ -386,12 +434,20 @@
   }
 
   function drawGrid() {
+    // Dot grid with a soft center vignette so the stage feels framed.
     ctx.save();
-    ctx.strokeStyle = "rgba(35, 39, 47, 0.4)";
-    ctx.lineWidth = 1;
-    const step = 40;
-    for (let x = 0; x < W; x += step) { ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke(); }
-    for (let y = 0; y < H; y += step) { ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke(); }
+    const step = 36;
+    const cx = W / 2, cy = H / 2;
+    const maxD = Math.hypot(cx, cy);
+    for (let x = step; x < W; x += step) {
+      for (let y = step; y < H; y += step) {
+        const d = Math.hypot(x - cx, y - cy) / maxD;   // 0 center → 1 corner
+        const alpha = 0.18 * (1 - d * 0.65);
+        if (alpha <= 0.01) continue;
+        ctx.fillStyle = `rgba(180, 196, 222, ${alpha})`;
+        ctx.beginPath(); ctx.arc(x, y, 0.9, 0, Math.PI * 2); ctx.fill();
+      }
+    }
     ctx.restore();
   }
 
@@ -1393,8 +1449,430 @@
     },
   };
 
+  // — helpers shared by the use-case scenes ————————————————————————————————
+  function drawPin(ctx, x, y, label, color = "#60a5fa") {
+    ctx.save();
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(x, y - 4, 8, Math.PI, 0);
+    ctx.lineTo(x, y + 8);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = "#0b0d10";
+    ctx.beginPath(); ctx.arc(x, y - 4, 3, 0, Math.PI * 2); ctx.fill();
+    if (label) {
+      ctx.fillStyle = "rgba(231, 233, 238, 0.85)";
+      ctx.font = "11px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(label, x, y + 24);
+    }
+    ctx.restore();
+  }
+
+  function drawDashedCurve(ctx, x1, y1, x2, y2, lift = 70, color = "rgba(96,165,250,0.35)") {
+    ctx.save();
+    ctx.setLineDash([5, 5]);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    const cx = (x1 + x2) / 2;
+    const cy = Math.min(y1, y2) - lift;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.quadraticCurveTo(cx, cy, x2, y2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.restore();
+  }
+
+  function bezierPoint(t, p0, p1, p2) {
+    const u = 1 - t;
+    return { x: u*u*p0.x + 2*u*t*p1.x + t*t*p2.x,
+             y: u*u*p0.y + 2*u*t*p1.y + t*t*p2.y };
+  }
+
+  // — Scene 10: Taxi handover ——————————————————————————————————————————————
+  // Centerpiece scene. Walks the full story: Patty's agent books a ride,
+  // matches with a driver, validates the offer (PQ sig + price + ETA),
+  // funds lock in dispatch escrow, GPS handshake on arrival, ride
+  // animates A→B, both agents confirm at the dropoff, escrow releases.
+  SCENES.taxi = {
+    id: "taxi",
+    name: "Taxi handover",
+    short: "10",
+    desc: "<strong>Patty</strong>'s agent books a ride. It RFQs <strong>Dispatch</strong>, picks <strong>Sai</strong> on price+ETA, validates the signed quote, locks funds in escrow, watches the GPS handshake at pickup, rides A→B, and releases on dropoff. Zero taps once policy is set.",
+    enter() {
+      setVisible(["bob", "driver", "dispatch", "escrow"]);
+      A.bob.balance = 25; A.bob.spent = 0; A.bob.dailyCap = 50;
+      A.driver.balance = 0; A.escrow.balance = 0;
+      this.layout();
+      this.phase = 0; this.cool = 50;
+      this.driveT = 0;
+      A.driver._visible = false; A.driver.pos = { ...this.pickup };
+      setCaption("step 1 / 8", "<strong>Patty</strong> at pin <strong>A</strong>. Her agent broadcasts a ride request to <strong>Dispatch</strong>.");
+      log(`<span class="info">taxi</span> scene loaded · pickup A → dropoff B`);
+    },
+    layout() {
+      this.pickup  = { x: W * 0.18, y: H * 0.72 };
+      this.dropoff = { x: W * 0.82, y: H * 0.30 };
+      A.bob.pos = { ...this.pickup };
+      A.dispatch.pos = { x: W * 0.5,  y: H * 0.18 };
+      A.escrow.pos   = { x: W * 0.5,  y: H * 0.82 };
+      A.driver.pos   = { ...this.pickup };
+    },
+    drawUnderlay(ctx, W, H) {
+      // map pins + curved route
+      drawPin(ctx, this.pickup.x, this.pickup.y, "A · pickup", "#7dd3fc");
+      drawPin(ctx, this.dropoff.x, this.dropoff.y, "B · dropoff", "#34d399");
+      drawDashedCurve(ctx, this.pickup.x, this.pickup.y, this.dropoff.x, this.dropoff.y, 110,
+                      "rgba(96,165,250,0.3)");
+    },
+    drawOverlay(ctx, W, H) {
+      // small "validate" badge on Patty while validating
+      if (this.phase === 3) {
+        ctx.fillStyle = "rgba(96, 165, 250, 0.9)";
+        ctx.font = "10px ui-monospace, Menlo, monospace";
+        ctx.textAlign = "center";
+        const a = A.bob;
+        ctx.fillText("validating: sig · price · ETA", a.pos.x, a.pos.y - a.radius - 16);
+      }
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      switch (this.phase) {
+        case 0:
+          emit("bob", "dispatch", { kind: "request", label: "ride A→B", speed: 0.02 });
+          log(`Patty → Dispatch: <code>requestRide(A, B)</code>`);
+          this.phase = 1; this.cool = 60;
+          setCaption("step 2 / 8", "<strong>Dispatch</strong> fans the request out to nearby drivers and collects bids.");
+          break;
+        case 1:
+          A.driver._visible = true;
+          A.driver.pos = { x: W * 0.85, y: H * 0.75 };
+          emit("driver", "dispatch", { kind: "bid", label: "$5.20 · 3 min", speed: 0.02 });
+          log(`Sai bids: <span class="warn">5.20 USDC · ETA 3 min</span> · PQ-signed quote`);
+          this.phase = 2; this.cool = 80;
+          setCaption("step 3 / 8", "Sai's agent returns a signed quote. Other drivers bid too; Dispatch forwards the winning offer.");
+          break;
+        case 2:
+          emit("dispatch", "bob", { kind: "offer", label: "Sai · 5.20", speed: 0.02 });
+          this.phase = 3; this.cool = 100;
+          setCaption("step 4 / 8", "Patty's agent validates the offer: <code>verify(sig, pk)</code>, price under cap, ETA under tolerance.");
+          break;
+        case 3:
+          emit("bob", "escrow", { kind: "offer", label: "lock 5.20", amount: 5.2, speed: 0.018,
+            onArrive: () => { A.bob.balance -= 5.2; A.escrow.balance += 5.2; } });
+          log(`Patty → Escrow: lock 5.20 USDC`);
+          this.phase = 4; this.cool = 90;
+          setCaption("step 5 / 8", "Funds lock in <span class=\"pill\">Escrow</span>. Sai's agent watches the lock event before rolling.");
+          break;
+        case 4: {
+          // animate Sai's car from off-screen position to pickup
+          this.driveT += 0.018;
+          const start = { x: W * 0.85, y: H * 0.75 };
+          A.driver.pos = {
+            x: lerp(start.x, this.pickup.x + 38, Math.min(1, this.driveT)),
+            y: lerp(start.y, this.pickup.y, Math.min(1, this.driveT)),
+          };
+          if (this.driveT >= 1) {
+            log(`Sai arrives at <strong>A</strong>. GPS handshake: <span class="ok">match</span>`);
+            emit("driver", "bob", { kind: "data", label: "GPS sig", speed: 0.03 });
+            emit("bob", "driver", { kind: "data", label: "GPS ack",  speed: 0.03 });
+            this.phase = 5; this.cool = 60; this.driveT = 0;
+            setCaption("step 6 / 8", "Sai pulls up. Both agents exchange signed GPS positions. Match → ride begins.");
+          }
+          break;
+        }
+        case 5: {
+          // animate the actual ride along the curve, both Patty and Sai together
+          this.driveT += 0.005;
+          const p0 = this.pickup;
+          const p2 = this.dropoff;
+          const p1 = { x: (p0.x + p2.x) / 2, y: Math.min(p0.y, p2.y) - 110 };
+          const pt = bezierPoint(Math.min(1, this.driveT), p0, p1, p2);
+          A.driver.pos = pt;
+          A.bob.pos = { x: pt.x - 28, y: pt.y + 2 };
+          if (this.driveT >= 1) {
+            log(`Arrived at <strong>B</strong>. Both agents confirm dropoff.`);
+            this.phase = 6; this.cool = 50; this.driveT = 0;
+            setCaption("step 7 / 8", "Arrival confirmed by both agents. Patty's app calls <code>confirmPayment()</code>.");
+          }
+          break;
+        }
+        case 6:
+          emit("bob", "escrow", { kind: "request", label: "confirm", speed: 0.022,
+            onArrive: () => {
+              emit("escrow", "driver", { kind: "proof", label: "released 5.20", speed: 0.022,
+                onArrive: () => {
+                  A.escrow.balance -= 5.2; A.driver.balance += 5.2;
+                  jobs++; jobsEl.textContent = jobs;
+                }});
+            }});
+          log(`<span class="ok">Escrow released 5.20 USDC to Sai</span> · handover complete`);
+          this.phase = 7; this.cool = 220;
+          setCaption("step 8 / 8", "Escrow releases 5.20 USDC to Sai. Receipt PQ-signed; Patty's done. No taps after step 1.");
+          break;
+        case 7:
+          // reset for loop
+          A.bob.balance = 25; A.bob.spent = 0;
+          A.driver.balance = 0; A.escrow.balance = 0;
+          this.driveT = 0; this.phase = 0;
+          this.layout();
+          A.driver._visible = false;
+          this.cool = 80;
+          break;
+      }
+    },
+  };
+
+  // — Scene 11: Café walk-up ——————————————————————————————————————————————
+  SCENES.cafe = {
+    id: "cafe",
+    name: "Café walk-up",
+    short: "11",
+    desc: "Smallest possible flow. <strong>Patty</strong> walks past <strong>Aroma</strong>'s shop, her agent does a proximity handshake, picks a latte off the signed menu, pays 4.50 USDC, takes the cup.",
+    enter() {
+      setVisible(["bob", "cafe"]);
+      A.bob.balance = 20; A.bob.spent = 0;
+      A.cafe.balance = 0;
+      this.layout();
+      this.phase = 0; this.cool = 50;
+      setCaption("step 1 / 5", "<strong>Patty</strong> approaches <strong>Aroma</strong>. Bluetooth-range handshake announces both agents to each other.");
+      log(`<span class="info">cafe</span> scene loaded`);
+    },
+    layout() {
+      A.bob.pos  = { x: W * 0.25, y: H * 0.55 };
+      A.cafe.pos = { x: W * 0.72, y: H * 0.5  };
+    },
+    drawUnderlay(ctx, W, H) {
+      // counter rectangle behind the cafe
+      ctx.save();
+      const x = W * 0.62, y = H * 0.35, w = W * 0.26, h = H * 0.32;
+      const g = ctx.createLinearGradient(x, y, x, y + h);
+      g.addColorStop(0, "rgba(251, 191, 36, 0.06)");
+      g.addColorStop(1, "rgba(251, 191, 36, 0.0)");
+      ctx.fillStyle = g;
+      ctx.strokeStyle = "rgba(251, 191, 36, 0.25)";
+      ctx.lineWidth = 1;
+      ctx.fillRect(x, y, w, h);
+      ctx.strokeRect(x, y, w, h);
+      ctx.fillStyle = "rgba(231, 233, 238, 0.5)";
+      ctx.font = "10px ui-monospace, Menlo, monospace";
+      ctx.fillText("AROMA  ·  espresso bar", x + 10, y + 16);
+      ctx.restore();
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      switch (this.phase) {
+        case 0:
+          emit("bob", "cafe", { kind: "request", label: "hello", speed: 0.03 });
+          emit("cafe", "bob", { kind: "data",    label: "menu (signed)", speed: 0.03 });
+          log(`handshake complete · Aroma sent signed menu`);
+          setCaption("step 2 / 5", "Aroma sends a PQ-signed menu. Patty's agent picks: latte 4.50 USDC.");
+          this.phase = 1; this.cool = 70;
+          break;
+        case 1:
+          emit("bob", "cafe", { kind: "offer", label: "latte · 4.50", amount: 4.5, speed: 0.022 });
+          setCaption("step 3 / 5", "Order placed. Aroma confirms availability and pricing.");
+          this.phase = 2; this.cool = 80;
+          break;
+        case 2:
+          emit("bob", "cafe", { kind: "offer", label: "X-Payment-Proof", amount: 4.5, speed: 0.022,
+            onArrive: () => { A.bob.balance -= 4.5; A.cafe.balance += 4.5; } });
+          log(`Patty pays 4.50 USDC via <code>X-Payment-Proof</code>`);
+          setCaption("step 4 / 5", "Payment settles. Aroma starts the latte.");
+          this.phase = 3; this.cool = 110;
+          break;
+        case 3:
+          emit("cafe", "bob", { kind: "data", label: "☕ ready", speed: 0.022 });
+          log(`<span class="ok">latte handed over</span> · receipt signed`);
+          setCaption("step 5 / 5", "Cup handover. Receipt is a PQ-signed proof — Patty leaves without touching the phone.");
+          jobs++; jobsEl.textContent = jobs;
+          this.phase = 4; this.cool = 200;
+          break;
+        case 4:
+          A.bob.balance = 20; A.cafe.balance = 0;
+          this.phase = 0; this.cool = 60;
+          break;
+      }
+    },
+  };
+
+  // — Scene 12: Food delivery (3-party) ————————————————————————————————————
+  SCENES.delivery = {
+    id: "delivery",
+    name: "Food delivery",
+    short: "12",
+    desc: "Three-party flow. <strong>Patty</strong> orders from <strong>Spice Hub</strong>; <strong>Kiran</strong> takes the delivery slot. Escrow splits the payout: food to the restaurant, tip to the rider. Rider's position animates along the route.",
+    enter() {
+      setVisible(["bob", "rest", "rider", "escrow"]);
+      A.bob.balance = 25; A.rest.balance = 0; A.rider.balance = 0;
+      A.escrow.balance = 0;
+      this.layout();
+      this.phase = 0; this.cool = 60;
+      this.tRide = 0;
+      A.rider._visible = false;
+      setCaption("step 1 / 7", "<strong>Patty</strong> orders from <strong>Spice Hub</strong>: ₹420 of biryani. Restaurant confirms.");
+      log(`<span class="info">delivery</span> scene loaded · multi-party escrow`);
+    },
+    layout() {
+      this.home = { x: W * 0.82, y: H * 0.68 };
+      this.restaurant = { x: W * 0.18, y: H * 0.32 };
+      A.bob.pos  = { ...this.home };
+      A.rest.pos = { ...this.restaurant };
+      A.escrow.pos = { x: W * 0.5, y: H * 0.85 };
+      A.rider.pos = { x: W * 0.1, y: H * 0.5 };
+    },
+    drawUnderlay(ctx, W, H) {
+      drawPin(ctx, this.restaurant.x, this.restaurant.y, "kitchen", "#f87171");
+      drawPin(ctx, this.home.x, this.home.y, "you", "#7dd3fc");
+      drawDashedCurve(ctx, this.restaurant.x, this.restaurant.y, this.home.x, this.home.y, 90,
+                      "rgba(115, 188, 130, 0.3)");
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      switch (this.phase) {
+        case 0:
+          emit("bob", "rest", { kind: "offer", label: "order 5.00", speed: 0.022 });
+          this.phase = 1; this.cool = 70;
+          setCaption("step 2 / 7", "Funds locked in escrow with a split policy: 80% to restaurant on pickup, 20% rider tip on delivery.");
+          break;
+        case 1:
+          emit("bob", "escrow", { kind: "offer", label: "lock 5.00", amount: 5.0, speed: 0.02,
+            onArrive: () => { A.bob.balance -= 5; A.escrow.balance += 5; } });
+          this.phase = 2; this.cool = 80;
+          setCaption("step 3 / 7", "Kiran's rider agent claims the slot — fastest ETA wins.");
+          A.rider._visible = true;
+          break;
+        case 2:
+          emit("rider", "escrow", { kind: "bid", label: "claim", speed: 0.022 });
+          log(`Kiran claims the delivery slot`);
+          this.phase = 3; this.cool = 60;
+          setCaption("step 4 / 7", "Kiran rides to the kitchen for pickup.");
+          break;
+        case 3: {
+          this.tRide += 0.012;
+          A.rider.pos = {
+            x: lerp(W * 0.1, this.restaurant.x + 36, Math.min(1, this.tRide)),
+            y: lerp(H * 0.5, this.restaurant.y + 6,  Math.min(1, this.tRide)),
+          };
+          if (this.tRide >= 1) {
+            log(`Pickup complete · 80% (4.00 USDC) released to Spice Hub`);
+            emit("escrow", "rest", { kind: "proof", label: "food paid 4.00", speed: 0.022,
+              onArrive: () => { A.escrow.balance -= 4; A.rest.balance += 4; } });
+            this.phase = 4; this.cool = 60; this.tRide = 0;
+            setCaption("step 5 / 7", "Pickup confirmed → 80% released to <strong>Spice Hub</strong>. Kiran rolls toward Patty.");
+          }
+          break;
+        }
+        case 4: {
+          this.tRide += 0.008;
+          const p0 = this.restaurant;
+          const p2 = this.home;
+          const p1 = { x: (p0.x + p2.x) / 2, y: Math.min(p0.y, p2.y) - 90 };
+          A.rider.pos = bezierPoint(Math.min(1, this.tRide), p0, p1, p2);
+          if (this.tRide >= 1) {
+            this.phase = 5; this.cool = 50; this.tRide = 0;
+            setCaption("step 6 / 7", "Delivery confirmed by Patty's agent. Rider tip released.");
+          }
+          break;
+        }
+        case 5:
+          emit("bob", "escrow", { kind: "request", label: "confirm delivery", speed: 0.022,
+            onArrive: () => {
+              emit("escrow", "rider", { kind: "proof", label: "tip 1.00", speed: 0.022,
+                onArrive: () => { A.escrow.balance -= 1; A.rider.balance += 1; }});
+            }});
+          log(`<span class="ok">Delivery complete</span> · tip 1.00 USDC → Kiran`);
+          this.phase = 6; this.cool = 220;
+          jobs++; jobsEl.textContent = jobs;
+          setCaption("step 7 / 7", "Done. Restaurant got food revenue at pickup; rider got the tip on confirmed delivery. Patty never touched a card.");
+          break;
+        case 6:
+          A.bob.balance = 25; A.rest.balance = 0; A.rider.balance = 0; A.escrow.balance = 0;
+          A.rider._visible = false; this.tRide = 0; this.phase = 0;
+          this.layout(); this.cool = 70;
+          break;
+      }
+    },
+  };
+
+  // — Scene 13: Split bill ——————————————————————————————————————————————
+  SCENES.split = {
+    id: "split",
+    name: "Split bill",
+    short: "13",
+    desc: "Four friends, one tab. Each agent computes its share against the signed line-items and pays the merchant simultaneously. The merchant only sees one settlement event: a complete bill. Drop-in for fintech apps that today require a single payer + chase-up later.",
+    enter() {
+      setVisible(["bob", "alice", "iris", "juno", "merchant"]);
+      A.bob.balance = 30; A.alice.balance = 30; A.iris.balance = 30; A.juno.balance = 30;
+      A.merchant.balance = 0;
+      this.total = 48.00;
+      this.share = this.total / 4;
+      this.layout();
+      this.phase = 0; this.cool = 60;
+      setCaption("step 1 / 3", `Bill: <code>${this.total.toFixed(2)} USDC</code>. Four agents see the signed itemized receipt and compute their share (${this.share.toFixed(2)} each).`);
+      log(`<span class="info">split</span> scene loaded · bill 48.00 USDC / 4 friends`);
+    },
+    layout() {
+      A.merchant.pos = { x: W * 0.5, y: H * 0.5 };
+      ring(["bob", "alice", "iris", "juno"], W * 0.5, H * 0.5, Math.min(W, H) * 0.3);
+    },
+    drawUnderlay(ctx, W, H) {
+      // round "table" behind the merchant
+      ctx.save();
+      const cx = W * 0.5, cy = H * 0.5, r = Math.min(W, H) * 0.22;
+      const g = ctx.createRadialGradient(cx, cy, r * 0.4, cx, cy, r);
+      g.addColorStop(0, "rgba(251, 191, 36, 0.06)");
+      g.addColorStop(1, "rgba(251, 191, 36, 0.0)");
+      ctx.fillStyle = g;
+      ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2); ctx.fill();
+      ctx.strokeStyle = "rgba(251, 191, 36, 0.22)";
+      ctx.setLineDash([3, 5]);
+      ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2); ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.restore();
+    },
+    tick(t) {
+      if (this.cool > 0) { this.cool--; return; }
+      switch (this.phase) {
+        case 0:
+          ["bob", "alice", "iris", "juno"].forEach(id => emit("merchant", id, { kind: "data", label: "receipt", speed: 0.024 }));
+          log(`Tridib's sends signed line-items to all four agents`);
+          this.phase = 1; this.cool = 70;
+          setCaption("step 2 / 3", "Each agent verifies the merchant's signature and the line-items it's accountable for, then fires its share.");
+          break;
+        case 1:
+          ["bob", "alice", "iris", "juno"].forEach((id, i) => {
+            setTimeout(() => {
+              emit(id, "merchant", { kind: "offer", label: this.share.toFixed(2),
+                amount: this.share, speed: 0.024,
+                onArrive: () => {
+                  A[id].balance -= this.share; A.merchant.balance += this.share;
+                  if (Math.abs(A.merchant.balance - this.total) < 0.001) {
+                    log(`<span class="ok">bill settled</span> · 4 payers, one event`);
+                    jobs++; jobsEl.textContent = jobs;
+                  }
+                }});
+              log(`${A[id].name} → Tridib's: ${this.share.toFixed(2)} USDC`);
+            }, i * 140);
+          });
+          this.phase = 2; this.cool = 200;
+          setCaption("step 3 / 3", "Merchant receives all four packets within one settlement window. No chasing, no Venmo IOU thread.");
+          break;
+        case 2:
+          A.bob.balance = 30; A.alice.balance = 30; A.iris.balance = 30; A.juno.balance = 30;
+          A.merchant.balance = 0;
+          this.phase = 0; this.cool = 80;
+          break;
+      }
+    },
+  };
+
   // ─── scene registry & switcher ────────────────────────────────────────────
-  const SCENE_ORDER = ["x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle", "pq", "stack"];
+  const SCENE_ORDER = [
+    "x402", "escrow", "stream", "auction", "hitl", "fanout", "oracle", "pq", "stack",
+    "taxi", "cafe", "delivery", "split",
+  ];
 
   function selectScene(id, force) {
     if (!force && currentScene && currentScene.id === id) return;

--- a/web/agents-demo.html
+++ b/web/agents-demo.html
@@ -144,6 +144,34 @@
     background: rgba(96, 165, 250, 0.18); border: none;
     box-shadow: 0 0 0 1px var(--accent); }
 
+  /* Per-scene simulation controls */
+  .ctl-panel { margin-top: 4px; }
+  .ctl-list { display: flex; flex-direction: column; gap: 8px;
+    font-family: var(--mono); font-size: 11px; margin-bottom: 8px; }
+  .ctl-row { display: flex; flex-direction: column; gap: 2px; }
+  .ctl-row label { color: var(--muted); display: flex; justify-content: space-between; }
+  .ctl-row .val { color: var(--fg); }
+  .ctl-row input[type=range] { width: 100%; accent-color: var(--accent); }
+  .ctl-row .preset { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px; }
+  .ctl-row .preset button { background: rgba(255,255,255,0.04); color: var(--muted);
+    border: 1px solid rgba(255,255,255,0.06); border-radius: 4px;
+    padding: 3px 8px; font: inherit; font-size: 10px; cursor: pointer; }
+  .ctl-row .preset button:hover { color: var(--fg); border-color: var(--accent); }
+  .ctl-row .preset button.active { background: rgba(96,165,250,0.12);
+    color: var(--fg); border-color: var(--accent); }
+  .ctl-btn { width: 100%; background: rgba(96,165,250,0.08);
+    color: var(--accent); border: 1px solid rgba(96,165,250,0.3);
+    border-radius: 6px; padding: 6px; font: inherit; font-size: 11px; cursor: pointer; }
+  .ctl-btn:hover { background: rgba(96,165,250,0.16); }
+  .why-card { background: rgba(125, 211, 252, 0.06);
+    border: 1px solid rgba(125, 211, 252, 0.18); border-radius: 6px;
+    padding: 9px 11px; font-size: 11px; line-height: 1.55; color: var(--fg);
+    margin-bottom: 10px; }
+  .why-card .lbl { color: var(--info); font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.05em; text-transform: uppercase; display: block; margin-bottom: 3px; }
+  .why-card ul { margin: 4px 0 0 0; padding-left: 16px; color: var(--muted); }
+  .why-card li { margin-bottom: 2px; }
+
   .log { font-family: var(--mono); font-size: 10px; line-height: 1.5; }
   .log .row { padding: 3px 0; border-bottom: 1px dashed var(--border);
     display: flex; gap: 6px; }
@@ -1055,6 +1083,14 @@
     name: "Escrow + refund",
     short: "02",
     desc: "Trust-minimized A2A via <code>AgentEscrow.sol</code>. Payer locks funds, payee delivers, payer confirms → release. If payee goes silent past <code>timeout_blocks + challenge_period</code>, payer reclaims.",
+    why: `An <strong>agentic payment escrow</strong> is the only on-chain primitive that interoperates cleanly across every other rail in this lab:
+      <ul>
+        <li><strong>x402 paywalls</strong> use it to settle off-chain proofs without trusting the merchant.</li>
+        <li><strong>Streaming MPP</strong> uses it to anchor session caps in code, not a vendor's promise.</li>
+        <li><strong>Marketplaces</strong> (auction, taxi, delivery) use it so bidders commit no funds until a counterparty is chosen, and a refund path exists for the unhappy case.</li>
+        <li><strong>PQ-signed envelopes</strong> need a settlement layer that verifies signatures before releasing — escrow is the natural place to enforce that.</li>
+      </ul>
+      Built once in 200 lines of Solidity, reused across every higher-level pattern. The alternative is a per-merchant centralized escrow service — exactly what crypto was supposed to remove.`,
     enter() {
       setVisible(["alice", "gus", "escrow", "deva", "hana"]);
       A.alice.balance = 10; A.gus.balance = 1;
@@ -1210,77 +1246,184 @@
   };
 
   // — Scene 4: AI compute auction ——————————————————————————————————————————
+  // Reworked: better placement, scrubbable bid + budget sliders in the
+  // sidebar, three scenario presets. Each phase is broken into smaller
+  // event beats so the user can follow what is happening.
   SCENES.auction = {
     id: "auction",
     name: "AI compute auction",
     short: "04",
-    desc: "Marketplace flow. <strong>Iris</strong> broadcasts a job (transcribe 10 minutes of audio). <strong>Abhi</strong>, <strong>Tridib</strong>, and <strong>Hana</strong> bid. Lowest bid wins; payment goes through escrow.",
+    desc: "Marketplace flow. <strong>Iris</strong> posts a transcription job. <strong>Abhi</strong>, <strong>Tridib</strong>, and <strong>Hana</strong> bid. Cheapest valid bid wins; payment goes through escrow. Drag the sliders below to change bid prices or Iris's budget — watch the outcome change.",
+    why: "Marketplaces today batch up bids on a centralized server and only emit one event when a winner is picked. Agents need <strong>granular events</strong> (each RFQ, each bid, the validation outcome) so they can react in-flight — drop out, re-bid, or refuse a winner whose signature doesn't validate. Switchboard models the marketplace as a sequence of small signed packets, not a single API call.",
+    controls: [
+      { id: "scenario", type: "preset", label: "Scenario",
+        default: "cheapestWins",
+        options: [
+          { label: "Cheapest wins",  value: "cheapestWins",  applyPreset: true },
+          { label: "All over budget", value: "overBudget",   applyPreset: true },
+          { label: "Tie",              value: "tie",           applyPreset: true },
+        ]},
+      { id: "budget",   type: "range", label: "Iris's max budget", min: 0.40, max: 3.00, step: 0.05, default: 1.50, suffix: "USDC", decimals: 2 },
+      { id: "bid_eli",  type: "range", label: "Abhi's bid",       min: 0.30, max: 3.00, step: 0.05, default: 1.20, suffix: "USDC", decimals: 2 },
+      { id: "bid_gus",  type: "range", label: "Tridib's bid",     min: 0.30, max: 3.00, step: 0.05, default: 0.90, suffix: "USDC", decimals: 2 },
+      { id: "bid_hana", type: "range", label: "Hana's bid",       min: 0.30, max: 3.00, step: 0.05, default: 1.05, suffix: "USDC", decimals: 2 },
+    ],
+    applyPreset(name) {
+      // Mutate the slider values + the live UI so the user sees the change.
+      const set = (id, v) => {
+        this.ctl[id] = v;
+        const input = document.getElementById("ctl-" + id);
+        const valEl = document.getElementById("ctl-" + id + "-val");
+        if (input) input.value = v;
+        if (valEl) valEl.textContent = v.toFixed(2) + " USDC";
+      };
+      if (name === "cheapestWins") {
+        set("budget", 1.50); set("bid_eli", 1.20); set("bid_gus", 0.90); set("bid_hana", 1.05);
+      } else if (name === "overBudget") {
+        set("budget", 0.80); set("bid_eli", 1.20); set("bid_gus", 1.10); set("bid_hana", 1.05);
+      } else if (name === "tie") {
+        set("budget", 1.50); set("bid_eli", 1.00); set("bid_gus", 1.00); set("bid_hana", 1.20);
+      }
+      selectScene("auction", true);   // restart with new params
+    },
     enter() {
       setVisible(["iris", "eli", "gus", "hana", "escrow"]);
-      A.iris.balance = 12; A.iris.spent = 0;
-      A.eli.balance = 1; A.gus.balance = 1; A.hana.balance = 1;
+      A.iris.balance = this.ctl.budget * 4; A.iris.spent = 0;
+      A.eli.balance = 0; A.gus.balance = 0; A.hana.balance = 0;
       this.layout();
       this.phase = 0; this.cool = 60;
-      this.bids = [];
+      this.bids = []; this.winner = null;
       A.eli.state = "listening"; A.gus.state = "listening"; A.hana.state = "listening";
-      setCaption("step 1 / 4", "Iris is about to broadcast a job to the listening providers.");
-      log(`<span class="info">auction</span> scene loaded`);
+      setCaption("event 1", "Iris drafts an RFQ for the job. Three providers are <em>listening</em> (dashed outer ring).");
+      log(`<span class="info">auction</span> scene loaded · budget ${this.ctl.budget.toFixed(2)} USDC`);
     },
     layout() {
-      A.iris.pos = { x: W * 0.2, y: H * 0.5 };
-      A.escrow.pos = { x: W * 0.55, y: H * 0.75 };
-      ring(["eli", "gus", "hana"], W * 0.72, H * 0.5, 130, -Math.PI/2);
+      // Clean placement: Iris on the left, providers stacked vertically on
+      // the right with comfortable spacing, escrow tucked at the bottom.
+      A.iris.pos   = { x: W * 0.22, y: H * 0.5  };
+      A.eli.pos    = { x: W * 0.72, y: H * 0.22 };
+      A.gus.pos    = { x: W * 0.78, y: H * 0.5  };
+      A.hana.pos   = { x: W * 0.72, y: H * 0.78 };
+      A.escrow.pos = { x: W * 0.46, y: H * 0.82 };
+    },
+    drawOverlay(ctx, W, H) {
+      // Show each provider's current bid floating above them.
+      const providers = [
+        { id: "eli",  bid: this.ctl.bid_eli  },
+        { id: "gus",  bid: this.ctl.bid_gus  },
+        { id: "hana", bid: this.ctl.bid_hana },
+      ];
+      ctx.save();
+      ctx.font = "10px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      providers.forEach(p => {
+        const a = A[p.id];
+        const overBudget = p.bid > this.ctl.budget;
+        ctx.fillStyle = overBudget ? "rgba(248, 113, 113, 0.85)" : "rgba(231, 233, 238, 0.75)";
+        ctx.fillText(`bid: ${p.bid.toFixed(2)} USDC${overBudget ? " · over cap" : ""}`,
+                     a.pos.x, a.pos.y - a.radius - 14);
+      });
+      // Iris's budget callout
+      ctx.fillStyle = "rgba(125, 211, 252, 0.85)";
+      ctx.fillText(`budget ≤ ${this.ctl.budget.toFixed(2)} USDC`,
+                   A.iris.pos.x, A.iris.pos.y - A.iris.radius - 14);
+      ctx.restore();
     },
     tick(t) {
       if (this.cool > 0) { this.cool--; return; }
-      if (this.phase === 0) {
-        ["eli","gus","hana"].forEach(id => emit("iris", id, { kind: "request", label: "RFQ", speed: 0.02 }));
-        log(`Iris broadcasts RFQ to ${3} providers`);
-        setCaption("step 2 / 4", "RFQ fans out. Providers price the job and respond with bids.");
-        this.phase = 1; this.cool = 70;
-      } else if (this.phase === 1) {
-        const bids = { eli: 1.20, gus: 0.90, hana: 1.05 };
-        Object.entries(bids).forEach(([id, price], i) => {
+      switch (this.phase) {
+        case 0: {
+          // event 2: Iris broadcasts the RFQ to each provider, one packet each
+          // for clearer beat-by-beat visualization.
+          ["eli","gus","hana"].forEach((id, i) => {
+            setTimeout(() => emit("iris", id, { kind: "request", label: "RFQ", speed: 0.026 }), i * 220);
+          });
+          log(`Iris broadcasts RFQ to 3 providers`);
+          setCaption("event 2", "RFQ packet leaves Iris three times — one per provider. Each provider's agent receives, prices the job, prepares a signed bid.");
+          this.phase = 1; this.cool = 90;
+          break;
+        }
+        case 1: {
+          // event 3: each provider returns a bid, staggered so they're individually readable
+          const bids = { eli: this.ctl.bid_eli, gus: this.ctl.bid_gus, hana: this.ctl.bid_hana };
+          Object.entries(bids).forEach(([id, price], i) => {
+            setTimeout(() => {
+              emit(id, "iris", { kind: "bid", label: `${price.toFixed(2)} USDC`, speed: 0.026,
+                onArrive: () => this.bids.push({ id, price }) });
+              log(`<span class="warn">${A[id].name}</span> bids ${price.toFixed(2)} USDC`);
+            }, i * 480);
+          });
+          setCaption("event 3", "Each provider signs and sends a bid back. Iris's agent collects them, verifies signatures, sorts by price.");
+          this.phase = 2; this.cool = 160;
+          break;
+        }
+        case 2: {
+          // event 4: pick a winner (or fail)
+          const valid = this.bids.filter(b => b.price <= this.ctl.budget);
+          if (valid.length === 0) {
+            log(`<span class="hot">no valid bids</span> · all over Iris's ${this.ctl.budget.toFixed(2)} USDC cap`);
+            setCaption("event 4 · abort", `Every bid exceeded Iris's budget cap. Auction aborts — <strong>no escrow lock</strong>, no commitment. Iris keeps her funds.`);
+            ["eli","gus","hana"].forEach(id => A[id].state = "passive");
+            this.phase = 5; this.cool = 220;
+            break;
+          }
+          valid.sort((a, b) => a.price - b.price);
+          // Tie? same lowest price — first-seen wins
+          const lowest = valid[0].price;
+          const tied = valid.filter(b => Math.abs(b.price - lowest) < 1e-9);
+          this.winner = tied[0];
+          ["eli","gus","hana"].forEach(id => { if (id !== this.winner.id) A[id].state = "passive"; });
+          if (tied.length > 1) {
+            log(`<span class="info">tie at ${lowest.toFixed(2)} USDC</span> · ${A[this.winner.id].name} wins on first-seen rule`);
+            setCaption("event 4 · tie-break", `Tie at ${lowest.toFixed(2)} USDC between ${tied.map(b => A[b.id].name).join(" + ")}. First-seen-wins: <strong>${A[this.winner.id].name}</strong>.`);
+          } else {
+            log(`<span class="ok">${A[this.winner.id].name} wins</span> at ${lowest.toFixed(2)} USDC`);
+            setCaption("event 4", `<strong>${A[this.winner.id].name}</strong> wins at ${lowest.toFixed(2)} USDC. Losing providers go passive — losing a bid costs them nothing.`);
+          }
+          this.phase = 3; this.cool = 100;
+          break;
+        }
+        case 3: {
+          // event 5: Iris locks funds in escrow
+          const w = this.winner;
+          emit("iris", "escrow", { kind: "offer", label: "lock " + w.price.toFixed(2),
+            amount: w.price, speed: 0.022,
+            onArrive: () => { A.iris.balance -= w.price; A.escrow.balance += w.price; }});
+          log(`Iris → Escrow: lock ${w.price.toFixed(2)} USDC for ${A[w.id].name}`);
+          setCaption("event 5", `Iris locks ${w.price.toFixed(2)} USDC in escrow against the winning bid. No funds leave Iris's wallet without the contract guarantee.`);
+          this.phase = 4; this.cool = 130;
+          break;
+        }
+        case 4: {
+          // event 6 + 7: delivery, confirm, release — separate beats
+          const w = this.winner;
+          emit(w.id, "iris", { kind: "data", label: "transcript", speed: 0.022 });
+          log(`${A[w.id].name} → Iris: transcript delivered`);
+          setCaption("event 6", `<strong>${A[w.id].name}</strong> performs the work and delivers a signed artifact to Iris.`);
           setTimeout(() => {
-            emit(id, "iris", { kind: "bid", label: `${price.toFixed(2)} USDC`, speed: 0.02,
-              onArrive: () => this.bids.push({ id, price }) });
-            log(`<span class="warn">${A[id].name}</span> bids ${price.toFixed(2)} USDC`);
-          }, i * 400);
-        });
-        this.phase = 2; this.cool = 120;
-      } else if (this.phase === 2) {
-        const winner = this.bids.sort((a,b) => a.price - b.price)[0];
-        if (!winner) { this.cool = 30; return; }
-        this.winner = winner;
-        ["eli","gus","hana"].forEach(id => { if (id !== winner.id) A[id].state = "passive"; });
-        log(`<span class="ok">${A[winner.id].name} wins</span> at ${winner.price.toFixed(2)} USDC`);
-        setCaption("step 3 / 4", `<strong>${A[winner.id].name}</strong> wins the auction. Iris locks funds in escrow.`);
-        emit("iris", "escrow", { kind: "offer", label: "lock " + winner.price.toFixed(2),
-          amount: winner.price, speed: 0.018,
-          onArrive: () => { A.iris.balance -= winner.price; A.escrow.balance += winner.price; }});
-        this.phase = 3; this.cool = 100;
-      } else if (this.phase === 3) {
-        // delivery + release
-        const w = this.winner;
-        emit(w.id, "iris", { kind: "data", label: "transcript", speed: 0.018 });
-        setTimeout(() => {
-          emit("iris", "escrow", { kind: "request", label: "confirm", speed: 0.02,
-            onArrive: () => {
-              emit("escrow", w.id, { kind: "proof", label: `released ${w.price.toFixed(2)}`, speed: 0.02,
-                onArrive: () => {
-                  A.escrow.balance -= w.price; A[w.id].balance += w.price;
-                  jobs++; jobsEl.textContent = jobs;
-                }});
-            }});
-        }, 1200);
-        setCaption("step 4 / 4", `Provider delivers → Iris confirms → escrow releases ${w.price.toFixed(2)} USDC. Losing bids cost nothing.`);
-        this.phase = 4; this.cool = 220;
-      } else if (this.phase === 4) {
-        // reset
-        this.bids = []; this.winner = null;
-        ["eli","gus","hana"].forEach(id => { A[id].state = "listening"; A[id].balance = 1; });
-        A.iris.balance = 12;
-        this.phase = 0; this.cool = 60;
+            emit("iris", "escrow", { kind: "request", label: "confirm", speed: 0.026,
+              onArrive: () => {
+                emit("escrow", w.id, { kind: "proof", label: `released ${w.price.toFixed(2)}`, speed: 0.024,
+                  onArrive: () => {
+                    A.escrow.balance -= w.price; A[w.id].balance += w.price;
+                    jobs++; jobsEl.textContent = jobs;
+                  }});
+                log(`Escrow released ${w.price.toFixed(2)} USDC to ${A[w.id].name}`);
+                setCaption("event 7", `Iris confirms → escrow releases. Winner credited; losers untouched. The protocol completes in ${this.bids.length + 4} signed packets total.`);
+              }});
+          }, 1400);
+          this.phase = 5; this.cool = 260;
+          break;
+        }
+        case 5: {
+          // reset loop
+          this.bids = []; this.winner = null;
+          ["eli","gus","hana"].forEach(id => { A[id].state = "listening"; A[id].balance = 0; });
+          A.iris.balance = this.ctl.budget * 4; A.iris.spent = 0;
+          A.escrow.balance = 0;
+          this.phase = 0; this.cool = 100;
+          break;
+        }
       }
     },
   };
@@ -2231,6 +2374,11 @@
     sceneTick = 0;
     for (const s of ALL) { s.state = "active"; s.spent = 0; }
     currentScene = SCENES[id];
+    // Initialize ctl bag from declared controls (if any) before enter() runs.
+    currentScene.ctl = {};
+    (currentScene.controls || []).forEach(c => {
+      currentScene.ctl[c.id] = c.default;
+    });
     currentScene.enter();
     // header
     document.getElementById("sceneTitle").textContent = currentScene.name;
@@ -2238,7 +2386,72 @@
     document.querySelectorAll("#sceneBar button").forEach(b => {
       b.classList.toggle("active", b.dataset.scene === id);
     });
+    renderControls(currentScene);
+    renderWhyCard(currentScene);
     log(`<span class="seg">— scene switched to <strong>${currentScene.name}</strong> —</span>`);
+  }
+
+  function renderControls(scene) {
+    const panel = document.getElementById("ctlPanel");
+    const list = document.getElementById("ctlList");
+    const resetBtn = document.getElementById("ctlReset");
+    if (!scene.controls || scene.controls.length === 0) {
+      panel.style.display = "none";
+      list.innerHTML = "";
+      return;
+    }
+    panel.style.display = "block";
+    list.innerHTML = "";
+    scene.controls.forEach(c => {
+      const row = document.createElement("div"); row.className = "ctl-row";
+      if (c.type === "range") {
+        const valSpan = `<span class="val" id="ctl-${c.id}-val">${scene.ctl[c.id].toFixed(c.decimals ?? 2)}${c.suffix ? " " + c.suffix : ""}</span>`;
+        row.innerHTML = `<label>${c.label}${valSpan}</label>
+          <input type="range" min="${c.min}" max="${c.max}" step="${c.step}" value="${scene.ctl[c.id]}" id="ctl-${c.id}">`;
+        list.appendChild(row);
+        const input = row.querySelector("input");
+        input.addEventListener("input", () => {
+          const v = parseFloat(input.value);
+          scene.ctl[c.id] = v;
+          document.getElementById(`ctl-${c.id}-val`).textContent =
+            v.toFixed(c.decimals ?? 2) + (c.suffix ? " " + c.suffix : "");
+          if (scene.onCtlChange) scene.onCtlChange(c.id, v);
+        });
+      } else if (c.type === "preset") {
+        row.innerHTML = `<label>${c.label}</label><div class="preset" id="preset-${c.id}"></div>`;
+        list.appendChild(row);
+        const wrap = row.querySelector(".preset");
+        c.options.forEach(opt => {
+          const b = document.createElement("button");
+          b.textContent = opt.label;
+          b.dataset.value = opt.value;
+          if (opt.value === scene.ctl[c.id]) b.classList.add("active");
+          b.addEventListener("click", () => {
+            scene.ctl[c.id] = opt.value;
+            wrap.querySelectorAll("button").forEach(x => x.classList.toggle("active", x.dataset.value === opt.value));
+            if (scene.onCtlChange) scene.onCtlChange(c.id, opt.value);
+            if (opt.applyPreset && scene.applyPreset) scene.applyPreset(opt.value);
+          });
+          wrap.appendChild(b);
+        });
+      }
+    });
+    resetBtn.onclick = () => selectScene(scene.id, true);
+  }
+
+  function renderWhyCard(scene) {
+    // Detach any previous why-card before re-mounting.
+    const existing = document.getElementById("whyCard");
+    if (existing) existing.remove();
+    if (!scene.why) return;
+    const aside = document.querySelector("aside.left");
+    const card = document.createElement("div");
+    card.className = "why-card";
+    card.id = "whyCard";
+    card.innerHTML = `<span class="lbl">why this matters</span>${scene.why}`;
+    // Insert directly after the scene description block.
+    const descEl = document.getElementById("sceneDesc");
+    descEl.parentNode.insertBefore(card, descEl.nextSibling);
   }
 
   // Group scene-bar by category for readability.

--- a/web/index.html
+++ b/web/index.html
@@ -89,6 +89,7 @@
     <p>Agent wallets, gas budgets, agent-to-agent escrow. Compatible with the open agent-payment rails of 2026: x402, MPP, AP2, Circle Nanopayments.</p>
   </div>
   <div style="display:flex;gap:14px;align-items:center">
+    <a href="./agents-demo.html">lab ↗</a>
     <a href="https://github.com/kcolbchain/switchboard">source</a>
     <a href="https://docs.kcolbchain.com/switchboard/">docs</a>
   </div>


### PR DESCRIPTION
**Status:** ready for review.

Continuation of #32 (closed; same diff, now hosted on an in-repo branch since Pattermesh has push access). All commits preserved.

## Two artifacts

### 1. RFC — \`docs/post-quantum.md\`

Application-layer PQ signatures on \`PaymentOffer\` / \`PaymentProof\` so receivers can verify offers *before* paying and authenticity survives Shor-class breaks.

Includes algorithm registry, domain-separated SHAKE-256 transcript, ZAP + dataclass wire additions, key-management module sketch, hybrid mode (ECDSA + ML-DSA-65, both halves must verify), threat model, migration plan v1.1 → v2.0, 13-item breakdown.

5 open design questions in §11. Sub-issues filed: #33 meta · #34 #35 #36 #37 #38 ready-to-ship.

### 2. Interactive lab — \`web/agents-demo.html\`

Single-file vanilla canvas demo (no build). **15 scenes** grouped on a pill bar:

**Primitives:** x402 paywall · escrow + refund · streaming MPP · AI compute auction · human-in-the-loop · treasury rebalance · oracle pull
**Use cases:** taxi handover · café walk-up · food delivery · split bill · native ETH escrow · subscription
**Meta:** PQ-signed envelopes (this RFC, animated) · repo coexistence (zap / x402 / gas-oracle / scout / arka / AgentEscrow)

**Shape taxonomy** — every agent declares a \`kind\`:
- **human** → squircle (Patty, Abhi, Tridib, Sara, Deva, Sai, Kiran)
- **bot** → octagon (autonomous AI agents)
- **contract** → hex (on-chain entities)

**Informatics-rich tooltips:** kind glyph + name, wallet pill + kind pill, one-line description, protocol pills (x402/MPP/ZAP/escrow), sig alg, last seen, balance/cap/spent. Glass-styled card.

**Polish:** split-flap "switchboard" title (hover to re-patch), eased sphere scale + ripple wave on hover, glass panels with backdrop-blur, dot-grid with center vignette, stage inner-border frame.

**Cast:** Patty / Abhi / Tridib are the three protagonists; Sara is a new human introduced for the split-bill scene.

**Developer-friendly:** "+ Add your scene" pill on the bar links to \`web/SCENES.md\` — a full scene template + agent registry reference + packet kinds + cast guidance + style guidance + a "bigger ideas wanted" list (insurance claim, royalty stream, IoT meter, KYC handshake, cross-chain).

### Tests

\`tests/test_web_lab.py\` — 22 cases covering HTML parse, structural anchors, split-flap wiring, all 15 scenes defined and ordered, kind/shape dispatch, tooltip informatics, scene-bar grouping, Add-yours CTA, SCENES.md presence, cast composition, JS \`node --check\`, hover affordances. All green.

Pre-existing nonce_manager failures on \`main\` (6 cases) untouched.

cc @abhicris