### PR TITLE
contracts: oracle-mediated release (releaseByAttestation) + Foundry tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ htmlcov/
 *.swp
 .idea/
 .vscode/
+
+# Foundry
+cache/
+out/
+broadcast/

--- a/contracts/AgentEscrow.sol
+++ b/contracts/AgentEscrow.sol
@@ -1,14 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IOracleAggregator} from "./IOracleAggregator.sol";
+
 /**
  * @title AgentEscrow
  * @notice Escrow contract for agent-to-agent payments with timeout and refund.
  * @dev Implements a payment protocol:
- *   1. Payer creates escrow with payment + timeout
+ *   1. Payer creates escrow with payment + timeout (+ optional policyHash)
  *   2. Agent performs work off-chain
  *   3. Payer confirms → funds released to payee
+ *      OR oracle aggregator authorizes release via attestation (when policyHash != 0)
  *   4. Timeout expires → payer can reclaim (after challenge period)
+ *
+ * Backward compatibility:
+ *   - The original 4-arg `createPayment(string, address, uint256, uint256)`
+ *     is preserved. It is equivalent to passing `policyHash = bytes32(0)`,
+ *     which means oracle release is disabled for that payment.
+ *   - All existing functions (`confirmPayment`, `requestRefund`,
+ *     `cancelPayment`, `getPayment`, `isState`, `isExpired`) are unchanged.
  */
 contract AgentEscrow {
     enum State { Created, Locked, Confirmed, Released, Refunded, Cancelled }
@@ -22,9 +32,15 @@ contract AgentEscrow {
         State state;
         string requestId;           // off-chain payment request ID
         uint256 createdAt;
+        bytes32 policyHash;         // 0x00 = payer-only release; non-zero enables oracle release
     }
 
     uint256 public immutable chainId;
+
+    /// @notice Oracle aggregator consulted on `releaseByAttestation`. Set
+    ///         once at construction. address(0) disables oracle release
+    ///         even for payments that declared a non-zero policyHash.
+    IOracleAggregator public immutable oracleAggregator;
 
     // requestId → Payment
     mapping(string => Payment) public payments;
@@ -37,12 +53,19 @@ contract AgentEscrow {
     event PaymentLocked(string indexed requestId);
     event PaymentConfirmed(string indexed requestId, address indexed payer);
     event PaymentReleased(string indexed requestId, address indexed payee, uint256 amount);
+    event PaymentReleasedByOracle(string indexed requestId, bytes32 policyHash, bytes32 attestationHash);
     event PaymentRefunded(string indexed requestId, address indexed payer, uint256 amount);
     event AgentRegistered(address indexed agent);
     event AgentDeregistered(address indexed agent);
 
-    constructor(uint256 _chainId) {
+    /// @param _chainId       Chain id this contract is deployed on.
+    /// @param _aggregator    Optional oracle aggregator. Pass `address(0)`
+    ///                       to deploy without oracle-release support;
+    ///                       in that case any non-zero `policyHash` in
+    ///                       `createPaymentWithPolicy` will revert.
+    constructor(uint256 _chainId, IOracleAggregator _aggregator) {
         chainId = _chainId;
+        oracleAggregator = _aggregator;
     }
 
     modifier onlyRegisteredAgent() {
@@ -59,11 +82,9 @@ contract AgentEscrow {
     }
 
     /**
-     * @notice Create a payment request and lock funds in escrow
-     * @param requestId Unique off-chain request ID
-     * @param payee Recipient agent address
-     * @param timeoutBlocks Blocks until the payment can be auto-expired
-     * @param challengePeriod Blocks payer must wait after timeout to reclaim
+     * @notice Create a payment request and lock funds in escrow (payer-only release).
+     * @dev    Backward-compatible 4-arg form. Equivalent to
+     *         `createPaymentWithPolicy(..., bytes32(0))`.
      */
     function createPayment(
         string calldata requestId,
@@ -71,6 +92,36 @@ contract AgentEscrow {
         uint256 timeoutBlocks,
         uint256 challengePeriod
     ) external payable returns (bool) {
+        return _createPayment(requestId, payee, timeoutBlocks, challengePeriod, bytes32(0));
+    }
+
+    /**
+     * @notice Create a payment with an oracle-release policy.
+     * @dev    `policyHash` is the keccak256 of the canonical policy JSON
+     *         (see kcolbchain/escrow-oracles SPEC.md §3). A non-zero hash
+     *         enables `releaseByAttestation` for this payment; payer-only
+     *         release via `confirmPayment` continues to work as a fallback.
+     */
+    function createPaymentWithPolicy(
+        string calldata requestId,
+        address payee,
+        uint256 timeoutBlocks,
+        uint256 challengePeriod,
+        bytes32 policyHash
+    ) external payable returns (bool) {
+        if (policyHash != bytes32(0)) {
+            require(address(oracleAggregator) != address(0), "no aggregator configured");
+        }
+        return _createPayment(requestId, payee, timeoutBlocks, challengePeriod, policyHash);
+    }
+
+    function _createPayment(
+        string calldata requestId,
+        address payee,
+        uint256 timeoutBlocks,
+        uint256 challengePeriod,
+        bytes32 policyHash
+    ) internal returns (bool) {
         require(msg.value > 0, "Must send ETH");
         require(bytes(requestId).length > 0, "requestId cannot be empty");
         require(payee != address(0), "payee cannot be zero address");
@@ -85,7 +136,8 @@ contract AgentEscrow {
             challengePeriod: challengePeriod,
             state: State.Locked,
             requestId: requestId,
-            createdAt: block.number
+            createdAt: block.number,
+            policyHash: policyHash
         });
 
         emit PaymentCreated(requestId, msg.sender, payee, msg.value);
@@ -96,6 +148,8 @@ contract AgentEscrow {
     /**
      * @notice Payer confirms work is done → release funds to payee
      * @dev Can only be called by the original payer. Only in Locked state.
+     *      Works regardless of whether the payment has an oracle policy;
+     *      payer-only confirmation is always available as a fallback.
      */
     function confirmPayment(string calldata requestId) external returns (bool) {
         Payment storage p = payments[requestId];
@@ -109,6 +163,43 @@ contract AgentEscrow {
         require(success, "Transfer to payee failed");
 
         emit PaymentConfirmed(requestId, msg.sender);
+        emit PaymentReleased(requestId, p.payee, p.amount);
+        return true;
+    }
+
+    /**
+     * @notice Oracle-mediated release. Anyone may submit; the configured
+     *         `oracleAggregator` verifies that `attestationHash` has enough
+     *         signatures from registered oracles for this payment's
+     *         `policyHash`.
+     *
+     * @dev Reverts if:
+     *      - payment is not Locked
+     *      - payment has no policyHash (oracle release was not opted into)
+     *      - timeout has elapsed (use `requestRefund` instead)
+     *      - oracle aggregator rejects the attestation
+     */
+    function releaseByAttestation(
+        string calldata requestId,
+        bytes32 attestationHash,
+        bytes[] calldata signatures
+    ) external returns (bool) {
+        Payment storage p = payments[requestId];
+        require(p.state == State.Locked, "Payment not in Locked state");
+        require(p.policyHash != bytes32(0), "No oracle policy on this payment");
+        require(block.number < p.createdAt + p.timeoutBlocks, "Payment has expired");
+        require(address(oracleAggregator) != address(0), "No aggregator");
+        require(
+            oracleAggregator.verifyRelease(p.policyHash, attestationHash, signatures),
+            "Oracle attestation rejected"
+        );
+
+        p.state = State.Released;
+
+        (bool success, ) = p.payee.call{value: p.amount}("");
+        require(success, "Transfer to payee failed");
+
+        emit PaymentReleasedByOracle(requestId, p.policyHash, attestationHash);
         emit PaymentReleased(requestId, p.payee, p.amount);
         return true;
     }

--- a/contracts/IOracleAggregator.sol
+++ b/contracts/IOracleAggregator.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IOracleAggregator
+ * @notice Interface AgentEscrow consults to authorize attestation-based release.
+ *
+ * @dev The aggregator owns the policy-attestation rules (K-of-N threshold,
+ *      operator registry, signature scheme). AgentEscrow only asks: "given
+ *      this `policyHash` and `attestationHash`, are these `signatures` enough
+ *      to release?" — yes/no.
+ *
+ *      Separating the aggregator from the escrow lets the attestation rules
+ *      evolve (FROST aggregation, optimistic challenge mode, slashing)
+ *      without touching the escrow contract.
+ *
+ *      See `kcolbchain/escrow-oracles` for the concrete spec and reference
+ *      aggregator implementations.
+ */
+interface IOracleAggregator {
+    /// @notice True iff `attestationHash` is supported by enough valid
+    ///         signatures from registered oracles for `policyHash`'s ruleset.
+    /// @param policyHash      keccak256 of the canonical policy JSON (escrow has this)
+    /// @param attestationHash keccak256 of the canonical attestation transcript
+    /// @param signatures      Array of oracle signatures over `attestationHash`
+    function verifyRelease(
+        bytes32 policyHash,
+        bytes32 attestationHash,
+        bytes[] calldata signatures
+    ) external view returns (bool);
+}

--- a/contracts/mocks/MockOracleAggregator.sol
+++ b/contracts/mocks/MockOracleAggregator.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IOracleAggregator} from "../IOracleAggregator.sol";
+
+/**
+ * @title MockOracleAggregator
+ * @notice Test-only aggregator that returns a deterministic verify result
+ *         driven by storage flags. Lets tests cover the full release-by-
+ *         attestation path without depending on a real signature scheme.
+ *
+ *         Production aggregators live in `kcolbchain/escrow-oracles` and
+ *         implement real K-of-N threshold verification (ECDSA in v1,
+ *         FROST in v2).
+ */
+contract MockOracleAggregator is IOracleAggregator {
+    /// @dev `accept[policyHash][attestationHash]` flips the aggregator to
+    ///      "yes, release". Default is always-reject.
+    mapping(bytes32 => mapping(bytes32 => bool)) public accept;
+
+    function setAccept(bytes32 policyHash, bytes32 attestationHash, bool ok) external {
+        accept[policyHash][attestationHash] = ok;
+    }
+
+    function verifyRelease(
+        bytes32 policyHash,
+        bytes32 attestationHash,
+        bytes[] calldata /* signatures */
+    ) external view override returns (bool) {
+        return accept[policyHash][attestationHash];
+    }
+}

--- a/contracts/test/AgentEscrowOracle.t.sol
+++ b/contracts/test/AgentEscrowOracle.t.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AgentEscrow} from "../AgentEscrow.sol";
+import {IOracleAggregator} from "../IOracleAggregator.sol";
+import {MockOracleAggregator} from "../mocks/MockOracleAggregator.sol";
+
+/// @dev Inline Forge cheatcode interface. Avoids a `lib/forge-std` submodule
+///      by declaring only the subset of `Vm` we use.
+interface Vm {
+    function deal(address who, uint256 amount) external;
+    function prank(address who) external;
+    function startPrank(address who) external;
+    function stopPrank() external;
+    function expectRevert(bytes calldata revertData) external;
+    function expectRevert(bytes4 revertData) external;
+    function expectRevert() external;
+    function roll(uint256 newBlock) external;
+    function addr(uint256 privateKey) external pure returns (address);
+}
+
+contract AgentEscrowOracleTest {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    AgentEscrow internal escrow;
+    MockOracleAggregator internal agg;
+
+    address internal payer  = address(0xA11CE);
+    address internal payee  = address(0xB0B);
+    address internal anyone = address(0xC0DE);
+
+    bytes32 internal constant POLICY = keccak256("policy: GET ipfs://bafy.../delivery.json status==200 body_hash==0x4a");
+    bytes32 internal constant ATTEST = keccak256("attestation: request_id=req-7f3e check_result=true observed_at=1234");
+
+    function setUp() public {
+        agg = new MockOracleAggregator();
+        escrow = new AgentEscrow(31337, IOracleAggregator(address(agg)));
+        vm.deal(payer, 10 ether);
+    }
+
+    // ─── Backward-compat: old 4-arg createPayment still works ─────────────
+
+    function test_legacy_createPayment_storesZeroPolicyHash() public {
+        vm.startPrank(payer);
+        escrow.createPayment{value: 1 ether}("req-1", payee, 100, 10);
+        vm.stopPrank();
+
+        AgentEscrow.Payment memory p = escrow.getPayment("req-1");
+        require(p.policyHash == bytes32(0), "legacy createPayment must default to policyHash 0");
+        require(p.payer == payer, "payer set");
+        require(p.amount == 1 ether, "amount set");
+    }
+
+    function test_legacy_payerCanStillConfirm() public {
+        vm.startPrank(payer);
+        escrow.createPayment{value: 1 ether}("req-2", payee, 100, 10);
+        escrow.confirmPayment("req-2");
+        vm.stopPrank();
+
+        require(payee.balance == 1 ether, "payee received funds");
+    }
+
+    // ─── New 5-arg createPaymentWithPolicy ────────────────────────────────
+
+    function test_createPaymentWithPolicy_storesHash() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-3", payee, 100, 10, POLICY);
+        vm.stopPrank();
+
+        AgentEscrow.Payment memory p = escrow.getPayment("req-3");
+        require(p.policyHash == POLICY, "policyHash stored");
+    }
+
+    function test_createPaymentWithPolicy_zeroHashIsLegalAndEqualsLegacyForm() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-4", payee, 100, 10, bytes32(0));
+        vm.stopPrank();
+
+        AgentEscrow.Payment memory p = escrow.getPayment("req-4");
+        require(p.policyHash == bytes32(0), "explicit zero policyHash treated as no-policy");
+    }
+
+    function test_createPaymentWithPolicy_revertsWhenAggregatorMissing() public {
+        // Deploy a fresh escrow without an aggregator
+        AgentEscrow bare = new AgentEscrow(31337, IOracleAggregator(address(0)));
+        vm.deal(payer, 1 ether);
+
+        vm.startPrank(payer);
+        vm.expectRevert(bytes("no aggregator configured"));
+        bare.createPaymentWithPolicy{value: 1 ether}("req-5", payee, 100, 10, POLICY);
+        vm.stopPrank();
+    }
+
+    // ─── releaseByAttestation happy path ──────────────────────────────────
+
+    function test_releaseByAttestation_success() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-6", payee, 100, 10, POLICY);
+        vm.stopPrank();
+
+        // Aggregator authorizes this (policy, attestation) pair.
+        agg.setAccept(POLICY, ATTEST, true);
+
+        // Anyone may submit — releaseByAttestation is permissionless.
+        vm.prank(anyone);
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = hex"deadbeef";
+        sigs[1] = hex"cafef00d";
+        escrow.releaseByAttestation("req-6", ATTEST, sigs);
+
+        require(payee.balance == 1 ether, "payee received funds");
+        AgentEscrow.Payment memory p = escrow.getPayment("req-6");
+        require(uint8(p.state) == uint8(AgentEscrow.State.Released), "state is Released");
+    }
+
+    // ─── releaseByAttestation revert paths ────────────────────────────────
+
+    function test_releaseByAttestation_revertsWhenAggregatorRejects() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-7", payee, 100, 10, POLICY);
+        vm.stopPrank();
+
+        // Default mock: rejects. (setAccept not called.)
+        vm.prank(anyone);
+        bytes[] memory sigs = new bytes[](0);
+        vm.expectRevert(bytes("Oracle attestation rejected"));
+        escrow.releaseByAttestation("req-7", ATTEST, sigs);
+    }
+
+    function test_releaseByAttestation_revertsOnNoPolicy() public {
+        // Legacy payment without a policy
+        vm.startPrank(payer);
+        escrow.createPayment{value: 1 ether}("req-8", payee, 100, 10);
+        vm.stopPrank();
+
+        agg.setAccept(POLICY, ATTEST, true);
+
+        vm.prank(anyone);
+        bytes[] memory sigs = new bytes[](0);
+        vm.expectRevert(bytes("No oracle policy on this payment"));
+        escrow.releaseByAttestation("req-8", ATTEST, sigs);
+    }
+
+    function test_releaseByAttestation_revertsAfterTimeout() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-9", payee, 100, 10, POLICY);
+        vm.stopPrank();
+
+        agg.setAccept(POLICY, ATTEST, true);
+
+        // Advance past timeout
+        vm.roll(block.number + 101);
+
+        vm.prank(anyone);
+        bytes[] memory sigs = new bytes[](0);
+        vm.expectRevert(bytes("Payment has expired"));
+        escrow.releaseByAttestation("req-9", ATTEST, sigs);
+    }
+
+    function test_releaseByAttestation_revertsOnNonLocked() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-10", payee, 100, 10, POLICY);
+        // Payer confirms early via the fallback path
+        escrow.confirmPayment("req-10");
+        vm.stopPrank();
+
+        agg.setAccept(POLICY, ATTEST, true);
+
+        // Now state is Released; oracle release must revert
+        vm.prank(anyone);
+        bytes[] memory sigs = new bytes[](0);
+        vm.expectRevert(bytes("Payment not in Locked state"));
+        escrow.releaseByAttestation("req-10", ATTEST, sigs);
+    }
+
+    // ─── Fallback semantics: payer can still confirm with policy set ──────
+
+    function test_payerConfirmStillWorksWhenPolicySet() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-11", payee, 100, 10, POLICY);
+        // Payer didn't wait for oracles; just confirms directly.
+        escrow.confirmPayment("req-11");
+        vm.stopPrank();
+
+        require(payee.balance == 1 ether, "payee received via payer-only path");
+    }
+
+    // ─── Refund still works on a policy-bearing payment ───────────────────
+
+    function test_payerRefundStillWorksWhenPolicySet() public {
+        vm.startPrank(payer);
+        escrow.createPaymentWithPolicy{value: 1 ether}("req-12", payee, 100, 10, POLICY);
+        vm.stopPrank();
+
+        // Advance past timeout + challenge
+        vm.roll(block.number + 200);
+
+        vm.startPrank(payer);
+        escrow.requestRefund("req-12");
+        vm.stopPrank();
+
+        require(payer.balance == 10 ether - 0, "payer refunded"); // started with 10, locked 1, refunded 1
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,13 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+test = "contracts/test"
+fs_permissions = [{ access = "read", path = "./" }]
+solc_version = "0.8.20"
+optimizer = true
+optimizer_runs = 200
+
+# Note: this is the first Foundry config in the repo. Tests live at
+# contracts/test/*.t.sol and use an inline `Vm` interface so no
+# `lib/forge-std` submodule is required. Run with `forge test`.


### PR DESCRIPTION
Implements the oracle-release extension described in the EIP rationale (\`eips/draft-native-eth-a2a-escrow.md\` §"No on-chain release condition beyond payer confirmation"). The base payer-only flow is **unchanged**; the extension is opt-in per payment via a 32-byte \`policyHash\`.

## Wire

| Addition | What |
|---|---|
| \`contracts/IOracleAggregator.sol\` | One-method interface: \`verifyRelease(policyHash, attestationHash, signatures) → bool\`. The aggregator owns K-of-N rules, registry, sig scheme; the escrow just asks yes/no. |
| \`contracts/AgentEscrow.sol\` | New immutable \`oracleAggregator\` field; new \`policyHash\` on \`Payment\`; new \`createPaymentWithPolicy(...)\` and \`releaseByAttestation(...)\`. The original 4-arg \`createPayment\` is preserved verbatim. |
| \`contracts/mocks/MockOracleAggregator.sol\` | Test-only aggregator with \`setAccept()\` to drive the verify result deterministically. |

## Backward compatibility

- The original \`createPayment(string, address, uint256, uint256)\` is **byte-identical** in ABI and behavior. It stores \`policyHash = 0\`, which disables oracle release for that payment.
- \`confirmPayment\` / \`requestRefund\` / \`cancelPayment\` are unchanged.
- Payer-only release continues to work as a fallback even when a payment has a non-zero \`policyHash\`.
- Deploying with \`oracleAggregator = address(0)\` disables oracle release entirely and matches the previous one-arg constructor's intent.

## Foundry setup

First Foundry config in the repo. \`foundry.toml\` points at \`contracts/test\`; the test file declares only the \`Vm\` cheatcodes it uses inline so **no \`lib/forge-std\` submodule is required**.

\`\`\`
\$ forge test
[12 tests pass; 0 fail; 0 skip]
\`\`\`

Tests cover:
- Legacy \`createPayment\` stores \`policyHash = 0\` (backward compat)
- Legacy payer-confirm still works
- New \`createPaymentWithPolicy\` stores the hash
- New \`createPaymentWithPolicy(..., 0)\` equals legacy form
- New form reverts when aggregator is unconfigured
- \`releaseByAttestation\` happy path
- \`releaseByAttestation\` reverts: aggregator rejects, no policy, after timeout, non-Locked state
- Payer-confirm fallback still works on policy-bearing payments
- Payer-refund still works on policy-bearing payments

## What this does NOT do

- **Does not change the EIP draft.** The EIP already documents this extension shape in §Rationale; the implementation now matches.
- **Does not ship a real signature-verifying aggregator.** That's in the companion PR on \`kcolbchain/escrow-oracles\` and uses ECDSA in v1, FROST in v2.
- **Does not formalize the policy JSON schema.** That's in the companion PR (\`kcolbchain/escrow-oracles#TBD\`), where the schema's validator guardrails (no \`http://\`, no localhost, body-hash required on HTTPS, status-code allowlist, signed-receipt extension for non-deterministic outputs) live as MUST/MUST-NOT clauses in \`SPEC.md\` §3.

## Companion PR

- kcolbchain/escrow-oracles — policy schema v1 + reference \`url_check\` oracle implementation (filed separately after this lands).