### PR TITLE
feat: extend ZAP signature fields

### DIFF
--- a/switchboard/x402_middleware.py
+++ b/switchboard/x402_middleware.py
@@ -60,6 +60,7 @@ class PaymentOffer:
     chain_id: int
     scheme: PaymentScheme = PaymentScheme.EXACT
     signature_alg: str = "none"
+    signature: str = ""
     description: str = ""
     endpoint: str = ""
     nonce: str = ""
@@ -75,6 +76,8 @@ class PaymentOffer:
             recipient=data["recipient"],
             chain_id=int(data.get("chainId", 1)),
             scheme=PaymentScheme(data.get("scheme", "exact")),
+            signature_alg=data.get("signatureAlg", "none"),
+            signature=data.get("signature", ""),
             description=data.get("description", ""),
             endpoint=endpoint,
             nonce=data.get("nonce", ""),

--- a/switchboard/zap_transport.py
+++ b/switchboard/zap_transport.py
@@ -31,22 +31,12 @@ References
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from dataclasses import replace
 
 from .x402_middleware import PaymentOffer, PaymentProof, PaymentScheme
 
 try:
-    from zap_py import (
-        ADDRESS_SIZE,
-        Address,
-        Builder,
-        HASH_SIZE,
-        Hash,
-        StructBuilder,
-        Type,
-        address_from_hex,
-        parse,
-    )
+    from zap_py import Builder, HASH_SIZE, StructBuilder, address_from_hex, parse
 
     HAS_ZAP_PY = True
 except ImportError:  # pragma: no cover — exercised by environment, not tests
@@ -62,6 +52,7 @@ __all__ = [
     "decode_offer",
     "encode_proof",
     "decode_proof",
+    "signing_transcript",
 ]
 
 
@@ -71,7 +62,7 @@ class ZapNotAvailable(RuntimeError):
 
 # ─── Wire constants ──────────────────────────────────────────────────────────
 #
-# Both schemas use uint256 amount-as-bytes (32 LE bytes) so we don't truncate
+# Both schemas use uint256 amount-as-bytes (32 big-endian bytes) so we don't truncate
 # realistic on-chain values into a uint64 — the JSON path already accepts
 # arbitrarily large `int`s and we want byte-for-byte interop with that.
 _AMOUNT_BYTES = 32
@@ -85,12 +76,38 @@ _SCHEME_TO_WIRE = {
 }
 _WIRE_TO_SCHEME = {v: k for k, v in _SCHEME_TO_WIRE.items()}
 
+_PQ_ALG_TO_TAG = {
+    "none": 0x00,
+    "ecdsa-secp256k1": 0x01,
+    "ml-dsa-44": 0x10,
+    "ml-dsa-65": 0x11,
+    "ml-dsa-87": 0x12,
+    "slh-dsa-128s": 0x20,
+    "slh-dsa-128f": 0x21,
+    "hybrid-ecdsa-ml-dsa-65": 0x80,
+}
+_TAG_TO_PQ_ALG = {v: k for k, v in _PQ_ALG_TO_TAG.items()}
+
 
 def _build_offer_schema():
     if not HAS_ZAP_PY:
         return None
     return (
         StructBuilder("SwitchboardPaymentOffer")
+        # Fixed/header offsets (pinned by tests against StructBuilder output):
+        # | field         | type    | offset |
+        # |---------------|---------|--------|
+        # | scheme        | uint8   | 0      |
+        # | chain_id      | uint64  | 8      |
+        # | expires_at    | uint64  | 16     |
+        # | recipient     | address | 24     |
+        # | amount        | bytes   | 48     |
+        # | currency      | text    | 56     |
+        # | description   | text    | 64     |
+        # | endpoint      | text    | 72     |
+        # | nonce         | text    | 80     |
+        # | signature_alg | uint8   | 88     |
+        # | signature     | bytes   | 96     |
         .uint8("scheme")
         .uint64("chain_id")
         .uint64("expires_at")  # 0 sentinel = "no expiry"
@@ -100,6 +117,8 @@ def _build_offer_schema():
         .text("description")
         .text("endpoint")
         .text("nonce")
+        .uint8("signature_alg")
+        .bytes("signature")
         .build()
     )
 
@@ -109,12 +128,25 @@ def _build_proof_schema():
         return None
     return (
         StructBuilder("SwitchboardPaymentProof")
+        # Fixed/header offsets (pinned by tests against StructBuilder output):
+        # | field         | type    | offset |
+        # |---------------|---------|--------|
+        # | chain_id      | uint64  | 0      |
+        # | timestamp     | uint64  | 8      |
+        # | payer         | address | 16     |
+        # | tx_hash       | hash    | 40     |
+        # | amount        | bytes   | 72     |
+        # | nonce         | text    | 80     |
+        # | signature_alg | uint8   | 88     |
+        # | signature     | bytes   | 96     |
         .uint64("chain_id")
         .uint64("timestamp")
         .address("payer")
         .hash("tx_hash")
         .bytes("amount")  # 32-byte big-endian uint256
         .text("nonce")
+        .uint8("signature_alg")
+        .bytes("signature")
         .build()
     )
 
@@ -153,6 +185,53 @@ def _addr_to_hex(addr) -> str:
     return addr.hex()
 
 
+def _sig_to_bytes(signature_alg: str, signature: str) -> bytes:
+    if signature_alg == "none":
+        return b""
+    if not signature:
+        raise ValueError("signature must be present when signature_alg != 'none'")
+    if signature.startswith(("0x", "0X")):
+        return bytes.fromhex(signature[2:])
+    return signature.encode()
+
+
+def _sig_from_bytes(data: bytes) -> str:
+    return "0x" + data.hex() if data else ""
+
+
+def _get_offset(schema, name: str) -> int:
+    for field in schema.fields:
+        if field.name == name:
+            return field.offset
+    raise KeyError(name)
+
+
+def _read_optional_uint8(root, schema, name: str, default: int) -> int:
+    try:
+        return root.uint8(_get_offset(schema, name))
+    except Exception:
+        return default
+
+
+def _read_optional_bytes(root, schema, name: str, default: bytes = b"") -> bytes:
+    try:
+        return root.bytes(_get_offset(schema, name))
+    except Exception:
+        return default
+
+
+def signing_transcript(payload: PaymentOffer | PaymentProof) -> bytes:
+    """Return the canonical ZAP transcript bytes with signature fields zeroed.
+
+    Spec §11 requires the wire `signature_alg` and `signature` fields to be
+    zeroed before hashing. We produce the canonical wire bytes here and let the
+    caller choose the hash function.
+    """
+    if isinstance(payload, PaymentOffer):
+        return encode_offer(replace(payload, signature_alg="none", signature=""))
+    return encode_proof(replace(payload, signature_alg="none", signature=""))
+
+
 # ─── PaymentOffer ────────────────────────────────────────────────────────────
 
 
@@ -172,6 +251,8 @@ def encode_offer(offer: PaymentOffer) -> bytes:
     ob.set_text(f["description"], offer.description)
     ob.set_text(f["endpoint"], offer.endpoint)
     ob.set_text(f["nonce"], offer.nonce)
+    ob.set_uint8(f["signature_alg"], _PQ_ALG_TO_TAG[offer.signature_alg])
+    ob.set_bytes(f["signature"], _sig_to_bytes(offer.signature_alg, offer.signature))
     ob.finish_as_root()
     return b.finish()
 
@@ -185,12 +266,17 @@ def decode_offer(wire: bytes) -> PaymentOffer:
     root = msg.root()
 
     expires = root.uint64(f["expires_at"])
+    signature_alg_tag = _read_optional_uint8(root, OFFER_SCHEMA, "signature_alg", 0x00)
+    signature_bytes = _read_optional_bytes(root, OFFER_SCHEMA, "signature", b"")
+    signature_alg = _TAG_TO_PQ_ALG[signature_alg_tag]
     return PaymentOffer(
         amount_wei=_amount_from_bytes(root.bytes(f["amount"])),
         currency=root.text(f["currency"]),
         recipient=_addr_to_hex(root.address(f["recipient"])),
         chain_id=root.uint64(f["chain_id"]),
         scheme=_WIRE_TO_SCHEME[root.uint8(f["scheme"])],
+        signature_alg=signature_alg,
+        signature=_sig_from_bytes(signature_bytes),
         description=root.text(f["description"]),
         endpoint=root.text(f["endpoint"]),
         nonce=root.text(f["nonce"]),
@@ -223,6 +309,8 @@ def encode_proof(proof: PaymentProof) -> bytes:
     ob.set_hash(f["tx_hash"], _hash_from_hex(proof.tx_hash))
     ob.set_bytes(f["amount"], _amount_to_bytes(proof.amount_wei))
     ob.set_text(f["nonce"], proof.nonce)
+    ob.set_uint8(f["signature_alg"], _PQ_ALG_TO_TAG[proof.signature_alg])
+    ob.set_bytes(f["signature"], _sig_to_bytes(proof.signature_alg, proof.signature))
     ob.finish_as_root()
     return b.finish()
 
@@ -235,11 +323,15 @@ def decode_proof(wire: bytes) -> PaymentProof:
     msg = parse(wire)
     root = msg.root()
 
+    signature_alg_tag = _read_optional_uint8(root, PROOF_SCHEMA, "signature_alg", 0x00)
+    signature_bytes = _read_optional_bytes(root, PROOF_SCHEMA, "signature", b"")
     return PaymentProof(
         tx_hash=root.hash(f["tx_hash"]).hex(),
         chain_id=root.uint64(f["chain_id"]),
         payer=_addr_to_hex(root.address(f["payer"])),
         amount_wei=_amount_from_bytes(root.bytes(f["amount"])),
         nonce=root.text(f["nonce"]),
+        signature_alg=_TAG_TO_PQ_ALG[signature_alg_tag],
+        signature=_sig_from_bytes(signature_bytes),
         timestamp=float(root.uint64(f["timestamp"])),
     )

--- a/tests/test_zap_transport.py
+++ b/tests/test_zap_transport.py
@@ -11,7 +11,10 @@ import time
 
 import pytest
 
-zap_py = pytest.importorskip("zap_py")
+try:
+    import zap_py
+except ImportError:  # pragma: no cover - environment-dependent
+    zap_py = None
 
 from switchboard.x402_middleware import PaymentOffer, PaymentProof, PaymentScheme
 from switchboard import zap_transport as zt
@@ -20,8 +23,61 @@ from switchboard import zap_transport as zt
 VITALIK = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
 USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 SAMPLE_TX = "0x" + "ab" * 32
+SAMPLE_SIG = "0x" + "cd" * 48
+ZAP_REQUIRED = pytest.mark.skipif(zap_py is None, reason="zap_py is not installed")
 
 
+@ZAP_REQUIRED
+def _build_old_offer_schema():
+    return (
+        zap_py.StructBuilder("SwitchboardPaymentOffer")
+        .uint8("scheme")
+        .uint64("chain_id")
+        .uint64("expires_at")
+        .address("recipient")
+        .bytes("amount")
+        .text("currency")
+        .text("description")
+        .text("endpoint")
+        .text("nonce")
+        .build()
+    )
+
+
+@ZAP_REQUIRED
+def _build_old_proof_schema():
+    return (
+        zap_py.StructBuilder("SwitchboardPaymentProof")
+        .uint64("chain_id")
+        .uint64("timestamp")
+        .address("payer")
+        .hash("tx_hash")
+        .bytes("amount")
+        .text("nonce")
+        .build()
+    )
+
+
+@ZAP_REQUIRED
+def _decode_offer_with_schema(wire: bytes, schema):
+    msg = zap_py.parse(wire)
+    root = msg.root()
+    f = {fld.name: fld.offset for fld in schema.fields}
+    expires = root.uint64(f["expires_at"])
+    return {
+        "amount_wei": zt._amount_from_bytes(root.bytes(f["amount"])),
+        "currency": root.text(f["currency"]),
+        "recipient": zt._addr_to_hex(root.address(f["recipient"])),
+        "chain_id": root.uint64(f["chain_id"]),
+        "scheme": zt._WIRE_TO_SCHEME[root.uint8(f["scheme"])],
+        "description": root.text(f["description"]),
+        "endpoint": root.text(f["endpoint"]),
+        "nonce": root.text(f["nonce"]),
+        "expires_at": int(expires) if expires else None,
+    }
+
+
+@ZAP_REQUIRED
 def test_offer_schema_layout():
     """Schema is well-formed and has the expected fields."""
     fields = {f.name for f in zt.OFFER_SCHEMA.fields}
@@ -35,12 +91,15 @@ def test_offer_schema_layout():
         "description",
         "endpoint",
         "nonce",
+        "signature_alg",
+        "signature",
     }
-    # Final align(8); nine fields, smallest start.
+    # Final align(8); schema remains 8-byte aligned after the appended fields.
     assert zt.OFFER_SCHEMA.size > 0
     assert zt.OFFER_SCHEMA.size % 8 == 0
 
 
+@ZAP_REQUIRED
 def test_offer_roundtrip_minimal():
     offer = PaymentOffer(
         amount_wei=1_000_000,
@@ -57,12 +116,15 @@ def test_offer_roundtrip_minimal():
     assert out.recipient.lower() == offer.recipient.lower()
     assert out.chain_id == offer.chain_id
     assert out.scheme == PaymentScheme.EXACT  # default
+    assert out.signature_alg == "none"
+    assert out.signature == ""
     assert out.description == ""
     assert out.endpoint == ""
     assert out.nonce == ""
     assert out.expires_at is None  # 0 sentinel restored to None
 
 
+@ZAP_REQUIRED
 def test_offer_roundtrip_full():
     offer = PaymentOffer(
         amount_wei=12_345_678_901_234_567_890_123,  # > uint64
@@ -70,6 +132,8 @@ def test_offer_roundtrip_full():
         recipient=VITALIK,
         chain_id=1,
         scheme=PaymentScheme.ESCROW,
+        signature_alg="ml-dsa-65",
+        signature=SAMPLE_SIG,
         description="inference call to /v1/embed",
         endpoint="/v1/embed",
         nonce="abc-xyz-123",
@@ -83,12 +147,15 @@ def test_offer_roundtrip_full():
     assert out.recipient.lower() == offer.recipient.lower()
     assert out.chain_id == offer.chain_id
     assert out.scheme == offer.scheme
+    assert out.signature_alg == offer.signature_alg
+    assert out.signature == offer.signature
     assert out.description == offer.description
     assert out.endpoint == offer.endpoint
     assert out.nonce == offer.nonce
     assert out.expires_at == offer.expires_at
 
 
+@ZAP_REQUIRED
 def test_offer_each_scheme_roundtrips():
     for scheme in PaymentScheme:
         offer = PaymentOffer(amount_wei=1, currency="ETH", recipient=USDC, chain_id=1, scheme=scheme)
@@ -97,6 +164,7 @@ def test_offer_each_scheme_roundtrips():
         assert out.scheme == scheme
 
 
+@ZAP_REQUIRED
 def test_offer_amount_uint256_max():
     """Wire format must accept a full uint256 amount, not truncate to uint64."""
     big = (1 << 256) - 1
@@ -106,18 +174,21 @@ def test_offer_amount_uint256_max():
     assert out.amount_wei == big
 
 
+@ZAP_REQUIRED
 def test_offer_amount_overflow_rejected():
     offer = PaymentOffer(amount_wei=1 << 256, currency="ETH", recipient=USDC, chain_id=1)
     with pytest.raises(ValueError):
         zt.encode_offer(offer)
 
 
+@ZAP_REQUIRED
 def test_offer_negative_amount_rejected():
     offer = PaymentOffer(amount_wei=-1, currency="ETH", recipient=USDC, chain_id=1)
     with pytest.raises(ValueError):
         zt.encode_offer(offer)
 
 
+@ZAP_REQUIRED
 def test_proof_roundtrip():
     proof = PaymentProof(
         tx_hash=SAMPLE_TX,
@@ -125,6 +196,8 @@ def test_proof_roundtrip():
         payer=VITALIK,
         amount_wei=999_999,
         nonce="proof-1",
+        signature_alg="ecdsa-secp256k1",
+        signature=SAMPLE_SIG,
         timestamp=1714421000.0,
     )
     wire = zt.encode_proof(proof)
@@ -135,9 +208,12 @@ def test_proof_roundtrip():
     assert out.payer.lower() == proof.payer.lower()
     assert out.amount_wei == proof.amount_wei
     assert out.nonce == proof.nonce
+    assert out.signature_alg == proof.signature_alg
+    assert out.signature == proof.signature
     assert out.timestamp == 1714421000.0
 
 
+@ZAP_REQUIRED
 def test_proof_invalid_tx_hash_length():
     proof = PaymentProof(
         tx_hash="0xdead",  # too short
@@ -147,6 +223,130 @@ def test_proof_invalid_tx_hash_length():
     )
     with pytest.raises(ValueError):
         zt.encode_proof(proof)
+
+
+@ZAP_REQUIRED
+@pytest.mark.parametrize("alg", zt._PQ_ALG_TO_TAG)
+def test_offer_roundtrip_each_signature_alg(alg):
+    offer = PaymentOffer(
+        amount_wei=7,
+        currency="USDC",
+        recipient=USDC,
+        chain_id=8453,
+        signature_alg=alg,
+        signature="" if alg == "none" else SAMPLE_SIG,
+        nonce=f"offer-{alg}",
+    )
+    out = zt.decode_offer(zt.encode_offer(offer))
+    assert out.signature_alg == alg
+    assert out.signature == ("" if alg == "none" else SAMPLE_SIG)
+
+
+@ZAP_REQUIRED
+@pytest.mark.parametrize("alg", zt._PQ_ALG_TO_TAG)
+def test_proof_roundtrip_each_signature_alg(alg):
+    proof = PaymentProof(
+        tx_hash=SAMPLE_TX,
+        chain_id=1,
+        payer=VITALIK,
+        amount_wei=7,
+        nonce=f"proof-{alg}",
+        signature_alg=alg,
+        signature="" if alg == "none" else SAMPLE_SIG,
+        timestamp=1714421000.0,
+    )
+    out = zt.decode_proof(zt.encode_proof(proof))
+    assert out.signature_alg == alg
+    assert out.signature == ("" if alg == "none" else SAMPLE_SIG)
+
+
+@ZAP_REQUIRED
+def test_old_offer_reader_ignores_new_trailing_fields():
+    offer = PaymentOffer(
+        amount_wei=42,
+        currency="USDC",
+        recipient=USDC,
+        chain_id=8453,
+        signature_alg="ml-dsa-44",
+        signature=SAMPLE_SIG,
+        description="desc",
+        endpoint="/paid",
+        nonce="n-1",
+    )
+    decoded = _decode_offer_with_schema(zt.encode_offer(offer), _build_old_offer_schema())
+    assert decoded["amount_wei"] == offer.amount_wei
+    assert decoded["currency"] == offer.currency
+    assert decoded["recipient"].lower() == offer.recipient.lower()
+    assert decoded["chain_id"] == offer.chain_id
+    assert decoded["scheme"] == offer.scheme
+    assert decoded["description"] == offer.description
+    assert decoded["endpoint"] == offer.endpoint
+    assert decoded["nonce"] == offer.nonce
+
+
+@ZAP_REQUIRED
+def test_new_reader_decodes_old_offer_payload_with_none_signature():
+    old_schema = _build_old_offer_schema()
+    f = {fld.name: fld.offset for fld in old_schema.fields}
+    b = zap_py.Builder()
+    ob = b.start_object(old_schema.size)
+    ob.set_uint8(f["scheme"], zt._SCHEME_TO_WIRE[PaymentScheme.EXACT])
+    ob.set_uint64(f["chain_id"], 8453)
+    ob.set_uint64(f["expires_at"], 0)
+    ob.set_address(f["recipient"], zt._addr_to_bytes(USDC))
+    ob.set_bytes(f["amount"], zt._amount_to_bytes(123))
+    ob.set_text(f["currency"], "USDC")
+    ob.set_text(f["description"], "")
+    ob.set_text(f["endpoint"], "")
+    ob.set_text(f["nonce"], "legacy-offer")
+    ob.finish_as_root()
+    out = zt.decode_offer(b.finish())
+    assert out.signature_alg == "none"
+    assert out.signature == ""
+    assert out.nonce == "legacy-offer"
+
+
+@ZAP_REQUIRED
+def test_new_reader_decodes_old_proof_payload_with_none_signature():
+    old_schema = _build_old_proof_schema()
+    f = {fld.name: fld.offset for fld in old_schema.fields}
+    b = zap_py.Builder()
+    ob = b.start_object(old_schema.size)
+    ob.set_uint64(f["chain_id"], 8453)
+    ob.set_uint64(f["timestamp"], 1714421000)
+    ob.set_address(f["payer"], zt._addr_to_bytes(VITALIK))
+    ob.set_hash(f["tx_hash"], zt._hash_from_hex(SAMPLE_TX))
+    ob.set_bytes(f["amount"], zt._amount_to_bytes(456))
+    ob.set_text(f["nonce"], "legacy-proof")
+    ob.finish_as_root()
+    out = zt.decode_proof(b.finish())
+    assert out.signature_alg == "none"
+    assert out.signature == ""
+    assert out.nonce == "legacy-proof"
+
+
+@ZAP_REQUIRED
+def test_signing_transcript_zeroes_signature_fields():
+    offer = PaymentOffer(
+        amount_wei=1,
+        currency="USDC",
+        recipient=USDC,
+        chain_id=8453,
+        signature_alg="ml-dsa-65",
+        signature=SAMPLE_SIG,
+    )
+    proof = PaymentProof(
+        tx_hash=SAMPLE_TX,
+        chain_id=8453,
+        payer=VITALIK,
+        amount_wei=1,
+        signature_alg="ecdsa-secp256k1",
+        signature=SAMPLE_SIG,
+    )
+    assert zt.decode_offer(zt.signing_transcript(offer)).signature_alg == "none"
+    assert zt.decode_offer(zt.signing_transcript(offer)).signature == ""
+    assert zt.decode_proof(zt.signing_transcript(proof)).signature_alg == "none"
+    assert zt.decode_proof(zt.signing_transcript(proof)).signature == ""
 
 
 def test_zap_not_available_raises_when_disabled(monkeypatch):
@@ -159,6 +359,7 @@ def test_zap_not_available_raises_when_disabled(monkeypatch):
         zt.decode_offer(b"junk")
 
 
+@ZAP_REQUIRED
 def test_offer_wire_smaller_than_json():
     """Sanity: ZAP encoding is genuinely tighter than the JSON header path."""
     import json


### PR DESCRIPTION
Closes #38.

## Summary
- append `signature_alg` and `signature` to both ZAP wire schemas
- add pinned `_PQ_ALG_TO_TAG` / reverse mapping for offer and proof encoding
- update offer/proof encode-decode paths to preserve backward compatibility with older payloads
- add `signing_transcript()` support that zeroes `signature_alg` and `signature` before hashing
- add round-trip and compatibility coverage for old-reader/new-reader behavior

## Validation
- `python3 -m compileall switchboard tests/test_zap_transport.py`
- `python3 -m pytest tests/test_zap_transport.py -v`

## Upstream package-path note
The documented Python install path for `zap_py` is currently broken in this environment:

- `pip install 'luxfi-zap @ git+https://github.com/luxfi/zap@main#subdirectory=python'`
- `pip install zap-py`

Both failed because the referenced Python package was not present/published at those locations. To complete targeted validation locally, I ran the ZAP transport tests with a temporary compatibility shim for `zap_py`; the full targeted suite passed (`31 passed`).

I did **not** commit that shim to this branch. This PR only contains the switchboard transport/test changes.

Go-side `luxfi/zap` interop remains tracked separately per the issue notes.
