### PR TITLE
fix(escrow): gate registerAgent + add deregisterAgent + transferOwnership

### DIFF
--- a/contracts/AgentEscrow.sol
+++ b/contracts/AgentEscrow.sol
@@ -21,6 +21,15 @@ import {IOracleAggregator} from "./IOracleAggregator.sol";
  *     `cancelPayment`, `getPayment`, `isState`, `isExpired`) are unchanged.
  */
 contract AgentEscrow {
+    /// @notice Contract owner — manages agent registration
+    address public owner;
+
+    /// @notice Restricts function access to the contract owner
+    modifier onlyOwner() {
+        require(msg.sender == owner, "AgentEscrow: caller is not the owner");
+        _;
+    }
+
     enum State { Created, Locked, Confirmed, Released, Refunded, Cancelled }
 
     struct Payment {
@@ -64,6 +73,7 @@ contract AgentEscrow {
     ///                       in that case any non-zero `policyHash` in
     ///                       `createPaymentWithPolicy` will revert.
     constructor(uint256 _chainId, IOracleAggregator _aggregator) {
+        owner = msg.sender;
         chainId = _chainId;
         oracleAggregator = _aggregator;
     }
@@ -74,11 +84,35 @@ contract AgentEscrow {
     }
 
     /**
-     * @notice Register an agent address (permissioned)
+     * @notice Register an agent address (owner-only).
+     * @dev Gated to prevent arbitrary address registration — only the
+     *      contract owner can add agents to the registry.
      */
-    function registerAgent(address agent) external {
+    function registerAgent(address agent) external onlyOwner {
         registeredAgents[agent] = true;
         emit AgentRegistered(agent);
+    }
+
+    /**
+     * @notice Deregister an agent address (owner-only).
+     * @dev Removes the agent from the registry and emits the previously
+     *      unused AgentDeregistered event. Reverts if the agent was not
+     *      previously registered.
+     */
+    function deregisterAgent(address agent) external onlyOwner {
+        require(registeredAgents[agent], "AgentEscrow: agent not registered");
+        registeredAgents[agent] = false;
+        emit AgentDeregistered(agent);
+    }
+
+    /**
+     * @notice Transfer contract ownership to a new address.
+     * @dev Only the current owner may call. Use with caution — ownership
+     *      grants agent-registry management.
+     */
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "AgentEscrow: new owner is zero address");
+        owner = newOwner;
     }
 
     /**

--- a/contracts/test/AgentEscrowOracle.t.sol
+++ b/contracts/test/AgentEscrowOracle.t.sol
@@ -38,6 +38,63 @@ contract AgentEscrowOracleTest {
         vm.deal(payer, 10 ether);
     }
 
+    // ─── Agent Registration Access Control ───────────────────────────────
+
+    function test_ownerCanRegisterAgent() public {
+        address newAgent = address(0xBEEF);
+        escrow.registerAgent(newAgent);
+        require(escrow.registeredAgents(newAgent), "agent should be registered");
+    }
+
+    function test_nonOwnerCannotRegisterAgent() public {
+        vm.startPrank(anyone);
+        vm.expectRevert(bytes("AgentEscrow: caller is not the owner"));
+        escrow.registerAgent(address(0xBEEF));
+        vm.stopPrank();
+    }
+
+    function test_ownerCanDeregisterAgent() public {
+        address agent = address(0xFEED);
+        escrow.registerAgent(agent);
+        require(escrow.registeredAgents(agent), "agent should be registered");
+        escrow.deregisterAgent(agent);
+        require(!escrow.registeredAgents(agent), "agent should be deregistered");
+    }
+
+    function test_deregisterUnregisteredReverts() public {
+        vm.expectRevert(bytes("AgentEscrow: agent not registered"));
+        escrow.deregisterAgent(address(0xDEAD));
+    }
+
+    function test_nonOwnerCannotDeregister() public {
+        // First register as owner
+        address agent = address(0xC0FFEE);
+        escrow.registerAgent(agent);
+        // Then try to deregister as non-owner
+        vm.startPrank(anyone);
+        vm.expectRevert(bytes("AgentEscrow: caller is not the owner"));
+        escrow.deregisterAgent(agent);
+        vm.stopPrank();
+    }
+
+    function test_ownerCanTransferOwnership() public {
+        address newOwner = address(0xF00D);
+        escrow.transferOwnership(newOwner);
+        require(escrow.owner() == newOwner, "ownership not transferred");
+    }
+
+    function test_nonOwnerCannotTransferOwnership() public {
+        vm.startPrank(anyone);
+        vm.expectRevert(bytes("AgentEscrow: caller is not the owner"));
+        escrow.transferOwnership(address(0xF00D));
+        vm.stopPrank();
+    }
+
+    function test_transferOwnershipToZeroReverts() public {
+        vm.expectRevert(bytes("AgentEscrow: new owner is zero address"));
+        escrow.transferOwnership(address(0));
+    }
+
     // ─── Backward-compat: old 4-arg createPayment still works ─────────────
 
     function test_legacy_createPayment_storesZeroPolicyHash() public {


### PR DESCRIPTION
Closes #88

## Problem
`registerAgent(address)` was permissionless — any caller could register arbitrary addresses, polluting the on-chain agent registry. `AgentDeregistered` event existed but was never emitted, and no `deregisterAgent` function existed.

## Fix
- Add inline `owner` + `onlyOwner` modifier (no external dependencies — consistent with project philosophy)
- Gate `registerAgent` with `onlyOwner`
- Add `deregisterAgent(address)` gated by `onlyOwner`, emitting the existing `AgentDeregistered` event
- Add `transferOwnership(address)` for owner rotation
- Constructor now sets `owner = msg.sender`

## Tests
8 new tests, all passing (`forge test` — 20/20):
- Owner can register/deregister agent
- Non-owner reverts on register, deregister, transferOwnership
- Deregister unregistered agent reverts
- Transfer to zero address reverts

## Backward Compatibility
- Existing registered agents remain unchanged
- All existing functions unchanged
- No external dependency added (inline owner pattern)