### PR TITLE
fix(nonce_manager): reuse freed/gap nonce instead of skipping it

### DIFF
--- a/switchboard/nonce_manager.py
+++ b/switchboard/nonce_manager.py
@@ -118,13 +118,19 @@ class NonceManager:
             # First, ensure our local state is synchronized with the latest on-chain nonce.
             self._sync_with_onchain_nonce(state, address)
 
-            # Determine the next available nonce.
-            # If there are any pending nonces, the next one is the highest pending + 1.
-            # Otherwise, it's the current `confirmed_nonce` (which should be the next expected nonce).
+            # Determine the next available nonce: the lowest nonce at or above
+            # `confirmed_nonce` that is not already pending. Walking up from
+            # `confirmed_nonce` (rather than taking ``max(pending) + 1``) means a
+            # nonce freed by `release_nonce` — or a gap left by an out-of-order
+            # confirmation — is reused before the sequence is extended. Ethereum
+            # requires gapless nonces, so leaving a hole would stall every
+            # higher-nonce pending tx until the gap is filled.
             next_nonce = state.confirmed_nonce
-            if state.pending_nonces:
-                next_nonce = max(state.pending_nonces) + 1
-            
+            for pending in state.pending_nonces.irange(minimum=next_nonce):
+                if pending != next_nonce:
+                    break
+                next_nonce += 1
+
             # Add the chosen nonce to the set of pending nonces.
             state.pending_nonces.add(next_nonce)
             if transaction is not None:

--- a/tests/test_nonce_manager.py
+++ b/tests/test_nonce_manager.py
@@ -199,6 +199,37 @@ class TestNonceManager(unittest.TestCase):
         self.nonce_manager.release_nonce(self.wallet_address_1, 5)
         self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet())
 
+    def test_release_lower_nonce_is_reused(self):
+        """
+        Releasing a lower nonce while a higher one is still pending must make the
+        freed nonce available again on the next acquire — not leave a permanent
+        gap. Ethereum requires gapless nonces, so a skipped nonce would stall
+        every higher-nonce pending transaction until the gap is filled.
+
+        Regression test: previously `acquire_nonce` returned `max(pending) + 1`,
+        which skipped the released nonce.
+        """
+        tx_w1_0 = MockTransaction(0, "w1_0")
+        tx_w1_1 = MockTransaction(1, "w1_1")
+        self.nonce_manager.acquire_nonce(self.wallet_address_1, tx_w1_0)  # nonce 0
+        self.nonce_manager.acquire_nonce(self.wallet_address_1, tx_w1_1)  # nonce 1
+        self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet([0, 1]))
+
+        # tx for nonce 0 fails locally before broadcast; free nonce 0 while 1 is still pending.
+        self.nonce_manager.release_nonce(self.wallet_address_1, 0)
+        self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet([1]))
+
+        # The next acquire must reuse the freed nonce 0, not jump to 2.
+        tx_w1_retry = MockTransaction(0, "w1_retry")
+        reused = self.nonce_manager.acquire_nonce(self.wallet_address_1, tx_w1_retry)
+        self.assertEqual(reused, 0)
+        self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet([0, 1]))
+
+        # A further acquire extends the sequence normally (no gaps remain).
+        tx_w1_2 = MockTransaction(2, "w1_2")
+        self.assertEqual(self.nonce_manager.acquire_nonce(self.wallet_address_1, tx_w1_2), 2)
+        self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet([0, 1, 2]))
+
     def test_sync_with_onchain_nonce_external_confirmation(self):
         """
         Tests synchronization with the on-chain nonce when external transactions


### PR DESCRIPTION
## What

`NonceManager.acquire_nonce` returned `max(pending_nonces) + 1` whenever any nonce was pending. When a **lower** nonce was freed by `release_nonce` (e.g. a tx that failed locally before broadcast) while a **higher** nonce was still pending, the freed nonce was never reissued — the next `acquire_nonce` jumped past it. The same hole appears after an out-of-order confirmation.

This change makes `acquire_nonce` return the lowest nonce at or above `confirmed_nonce` that is not already pending, walking the `SortedSet` from `confirmed_nonce` via `irange`.

## Why

Ethereum requires **gapless** nonces. A skipped nonce leaves a permanent hole, and every higher-nonce pending transaction sits in the mempool unmined until that hole is filled — a liveness bug for any agent that ever releases a nonce. It also contradicted `release_nonce`'s own docstring, which states it frees the nonce "making it available again."

Repro on `main`:

```python
nm.acquire_nonce(addr)        # -> 0
nm.acquire_nonce(addr)        # -> 1
nm.release_nonce(addr, 0)     # tx0 failed locally; free nonce 0
nm.acquire_nonce(addr)        # -> 2  (BUG: skips the freed nonce 0)
```

After the fix the final call returns `0`.

In the gapless common case the result is identical to the old `max + 1` behaviour, so existing callers are unaffected. All existing `nonce_manager` tests pass unchanged.

## Tests

Added `test_release_lower_nonce_is_reused`, which releases a lower nonce while a higher one stays pending and asserts the freed nonce is reused, then that the sequence extends normally afterward.

- `pytest tests/test_nonce_manager.py -v` → **10 passed**
- `pytest -q` (full suite) → **171 passed, 56 skipped**
- `ruff check switchboard/nonce_manager.py` → clean

No related open issue; this is a standalone correctness fix to the nonce manager (introduced in PR #11) that hardens the same component issue #79 plans to extend.
