### PR TITLE
fix(x402): treat expires_at == 0 as the "no expiry" sentinel

### DIFF
--- a/switchboard/x402_middleware.py
+++ b/switchboard/x402_middleware.py
@@ -85,7 +85,12 @@ class PaymentOffer:
         )
 
     def is_expired(self) -> bool:
-        if self.expires_at is None:
+        # ``0`` is the "no expiry" sentinel on the ZAP wire format (see
+        # ``zap_transport.py``: ``expires_at`` is encoded as ``offer.expires_at or 0``
+        # and decoded back with ``int(expires) if expires else None``). Treat a falsy
+        # ``expires_at`` (``None`` or ``0``) as "never expires" so the JSON/header path
+        # agrees with the binary path instead of rejecting a no-expiry offer as expired.
+        if not self.expires_at:
             return False
         return time.time() > self.expires_at
 

--- a/tests/test_x402_middleware.py
+++ b/tests/test_x402_middleware.py
@@ -60,6 +60,28 @@ class TestPaymentOffer:
         )
         assert not offer.is_expired()
 
+    def test_zero_expiry_is_no_expiry_sentinel(self):
+        # ``0`` is the documented "no expiry" sentinel on the ZAP wire format
+        # (zap_transport.py). The JSON/header path must agree: an offer with
+        # expiresAt == 0 must NOT be treated as expired (regression for the
+        # cross-transport inconsistency where ``time.time() > 0`` is always True).
+        offer = PaymentOffer.from_header(
+            json.dumps({"amount": "1000", "recipient": "0x1", "chainId": 1, "expiresAt": 0})
+        )
+        assert offer.expires_at == 0
+        assert not offer.is_expired()
+
+    def test_zero_expiry_offer_not_rejected_by_validation(self):
+        # End-to-end: a no-expiry (sentinel 0) offer must pass _validate_offer,
+        # not raise "Payment offer expired".
+        client = MagicMock()
+        client.wallet_address = "0xPAYER"
+        mw = X402Middleware(payment_client=client, max_payment_wei=10**18)
+        offer = PaymentOffer(
+            amount_wei=100, currency="ETH", recipient="0x1", chain_id=1, expires_at=0
+        )
+        mw._validate_offer(offer)  # must not raise
+
 
 # ─── PaymentProof Tests ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`PaymentOffer.is_expired()` only special-cased `None`:

```python
def is_expired(self) -> bool:
    if self.expires_at is None:
        return False
    return time.time() > self.expires_at
```

So an offer with `expires_at == 0` evaluates `time.time() > 0`, which is **always** `True` → the offer reports itself expired, and `X402Middleware._validate_offer()` rejects it with `Payment offer expired at 0`.

## Why 0 should mean "no expiry"

`0` is the project's **own documented "no expiry" sentinel** on the ZAP wire format. From `switchboard/zap_transport.py`:

- schema comment: `.uint64("expires_at")  # 0 sentinel = "no expiry"`
- encode: `ob.set_uint64(f["expires_at"], offer.expires_at or 0)`  (`None` → `0`)
- decode: `expires_at=int(expires) if expires else None`  (`0` → `None`)

So a never-expiring offer that round-trips through the binary path (`None` → `0`) — or any 402 server that sends `{"expiresAt": 0}` to mean "never expires" — is then wrongly treated as expired on the JSON/header path. The two transports disagree.

### Reproduce

```python
from switchboard.x402_middleware import PaymentOffer
import json
offer = PaymentOffer.from_header(json.dumps(
    {"amount": "1000", "recipient": "0x1", "chainId": 1, "expiresAt": 0}))
assert offer.is_expired() is False  # currently True
```

## Fix

Treat a falsy `expires_at` (`None` **or** `0`) as "never expires", aligning the JSON/header path with the ZAP binary path. Behaviour for `None` and for positive timestamps is unchanged.

## Tests

Adds two regression tests (the unit case + the `_validate_offer` end-to-end case). Full suite: **173 passed, 56 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)