### PR TITLE
L2: Reconcile gas_budget.py and gas_tracker.py into unified GasManager

### DIFF
--- a/switchboard/__init__.py
+++ b/switchboard/__init__.py
@@ -10,7 +10,10 @@ from typing import Any
 
 __version__ = "0.1.0"
 
-__all__ = ["__version__", "load_registry"]
+__all__ = ["__version__", "load_registry", "GasManager", "GasLimits", "BudgetStatus", "BudgetExhausted"]
+
+
+from switchboard.gas_manager import BudgetExhausted, GasLimits, GasManager, BudgetStatus
 
 
 def load_registry() -> dict[str, Any]:

--- a/switchboard/gas_manager.py
+++ b/switchboard/gas_manager.py
@@ -1,0 +1,280 @@
+"""
+Unified gas budget manager — reconciles ``gas_budget.py`` and ``gas_tracker.py``.
+
+Combines per-wallet accounting (GasBudgetTracker) with auto-unpause on window
+rollover (GasTracker), providing a single drop-in replacement for both.
+
+Design
+------
+- Per-wallet rolling-window enforcement (deque-based, not calendar buckets).
+- Thread-safe via single reentrant lock.
+- Auto-unpauses a wallet when the rolling window frees up capacity.
+- Pluggable clock for deterministic tests.
+- Pure Python, zero new runtime deps.
+
+Usage
+-----
+    manager = GasManager(
+        default_limits=GasLimits(per_hour=2_000_000, per_day=20_000_000),
+    )
+
+    if not manager.can_spend("0xAgent", estimated_gas):
+        raise BudgetExhausted(manager.status("0xAgent"))
+
+    # ... send tx ...
+    manager.record("0xAgent", gas_used=receipt.gasUsed)
+
+    # GasTracker-compatible alias:
+    manager.record_gas_usage("0xAgent", gas_used)
+
+References
+----------
+- Issue #97: https://github.com/kcolbchain/switchboard/issues/97
+- Original modules: gas_budget.py (GasBudgetTracker), gas_tracker.py (GasTracker)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, Dict, Optional, Tuple
+
+
+SECONDS_PER_HOUR = 3_600
+SECONDS_PER_DAY = 86_400
+
+
+class BudgetExhausted(RuntimeError):
+    """Raised when a wallet would exceed its configured gas budget."""
+
+
+@dataclass(frozen=True)
+class GasLimits:
+    """Per-wallet gas ceilings. ``None`` disables the corresponding window."""
+
+    per_hour: Optional[int] = None
+    per_day: Optional[int] = None
+
+
+@dataclass
+class BudgetStatus:
+    """Snapshot of a wallet's current spend vs. its limits."""
+
+    wallet: str
+    limits: GasLimits
+    spent_last_hour: int
+    spent_last_day: int
+    paused: bool
+
+    @property
+    def remaining_hour(self) -> Optional[int]:
+        if self.limits.per_hour is None:
+            return None
+        return max(0, self.limits.per_hour - self.spent_last_hour)
+
+    @property
+    def remaining_day(self) -> Optional[int]:
+        if self.limits.per_day is None:
+            return None
+        return max(0, self.limits.per_day - self.spent_last_day)
+
+
+@dataclass
+class _WalletLedger:
+    """Internal per-wallet state. Protected by the tracker lock."""
+
+    events: Deque = field(default_factory=deque)
+    sum_hour: int = 0
+    sum_day: int = 0
+    paused: bool = False
+
+
+class GasManager:
+    """Tracks cumulative gas per wallet and enforces rolling-window limits.
+
+    Unifies the API of :class:`GasBudgetTracker` and :class:`GasTracker`
+    so that either codebase can migrate without behavioural surprises.
+
+    Parameters
+    ----------
+    default_limits:
+        Applied to any wallet that does not have explicit limits set via
+        :meth:`set_limits`.
+    clock:
+        Injectable seconds-resolution clock.  Defaults to :func:`time.time`.
+        Tests should pass a controllable clock.
+    """
+
+    def __init__(
+        self,
+        default_limits: GasLimits = GasLimits(),
+        clock: Callable[[], float] = time.time,
+    ):
+        self._default_limits = default_limits
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._ledgers: Dict[str, _WalletLedger] = defaultdict(_WalletLedger)
+        self._limits: Dict[str, GasLimits] = {}
+
+    # ---- configuration -------------------------------------------------
+
+    def set_limits(self, wallet: str, limits: GasLimits) -> None:
+        """Override the default limits for ``wallet``."""
+        with self._lock:
+            self._limits[wallet] = limits
+            self._update_pause_state_locked(self._ledgers[wallet], limits)
+
+    def limits_for(self, wallet: str) -> GasLimits:
+        return self._limits.get(wallet, self._default_limits)
+
+    # ---- GasBudgetTracker-compatible API --------------------------------
+
+    def can_spend(self, wallet: str, estimated_gas: int) -> bool:
+        """Return ``True`` if ``estimated_gas`` fits within every active window."""
+        if estimated_gas < 0:
+            raise ValueError("estimated_gas must be non-negative")
+
+        with self._lock:
+            ledger = self._ledgers[wallet]
+            limits = self.limits_for(wallet)
+            self._evict_locked(ledger, limits)
+
+            if ledger.paused:
+                return False
+            if limits.per_hour is not None and ledger.sum_hour + estimated_gas > limits.per_hour:
+                return False
+            if limits.per_day is not None and ledger.sum_day + estimated_gas > limits.per_day:
+                return False
+            return True
+
+    def check(self, wallet: str, estimated_gas: int) -> None:
+        """Raise :class:`BudgetExhausted` if ``estimated_gas`` cannot be spent."""
+        if not self.can_spend(wallet, estimated_gas):
+            raise BudgetExhausted(self.status(wallet))
+
+    def record(self, wallet: str, gas_used: int) -> BudgetStatus:
+        """Record a post-confirmation gas spend and return the new status.
+
+        Auto-pauses the wallet if a limit is crossed after this record.
+        """
+        if gas_used < 0:
+            raise ValueError("gas_used must be non-negative")
+
+        with self._lock:
+            ledger = self._ledgers[wallet]
+            limits = self.limits_for(wallet)
+            self._evict_locked(ledger, limits)
+
+            now = self._clock()
+            ledger.events.append((now, gas_used))
+            ledger.sum_hour += gas_used
+            ledger.sum_day += gas_used
+            crossed = (
+                (limits.per_hour is not None and ledger.sum_hour >= limits.per_hour)
+                or (limits.per_day is not None and ledger.sum_day >= limits.per_day)
+            )
+            if crossed:
+                ledger.paused = True
+
+            return self._status_locked(wallet, ledger, limits)
+
+    # ---- GasTracker-compatible API --------------------------------------
+
+    def can_send_transaction(self, wallet: str, estimated_gas: int) -> bool:
+        """Alias for :meth:`can_spend` — GasTracker compatibility."""
+        return self.can_spend(wallet, estimated_gas)
+
+    def record_gas_usage(self, wallet: str, gas_used: int) -> None:
+        """Alias for ``record()`` — GasTracker compatibility (no return)."""
+        self.record(wallet, gas_used)
+
+    def is_paused(self, wallet: str) -> bool:
+        """Return whether ``wallet`` is currently paused."""
+        return self.status(wallet).paused
+
+    def get_current_spent(self, wallet: str) -> Tuple[int, int]:
+        """Return ``(spent_last_hour, spent_last_day)`` — GasTracker compatibility."""
+        s = self.status(wallet)
+        return (s.spent_last_hour, s.spent_last_day)
+
+    # ---- introspection -------------------------------------------------
+
+    def status(self, wallet: str) -> BudgetStatus:
+        with self._lock:
+            ledger = self._ledgers[wallet]
+            limits = self.limits_for(wallet)
+            self._evict_locked(ledger, limits)
+            return self._status_locked(wallet, ledger, limits)
+
+    def resume(self, wallet: str) -> None:
+        """Manually unpause a wallet."""
+        with self._lock:
+            self._ledgers[wallet].paused = False
+
+    def reset(self, wallet: str) -> None:
+        """Clear all recorded spend for ``wallet``."""
+        with self._lock:
+            self._ledgers[wallet] = _WalletLedger()
+
+    def reset_all(self) -> None:
+        """Clear all wallets — GasTracker compatibility."""
+        with self._lock:
+            self._ledgers.clear()
+
+    # ---- internals -----------------------------------------------------
+
+    def _evict_locked(
+        self, ledger: _WalletLedger, limits: Optional[GasLimits] = None
+    ) -> None:
+        """Drop events that have aged out of both windows and refresh sums.
+
+        Auto-unpauses if the remaining spend is below every active limit
+        (requires ``limits`` to be passed for the check).
+        """
+        now = self._clock()
+        day_cutoff = now - SECONDS_PER_DAY
+        hour_cutoff = now - SECONDS_PER_HOUR
+
+        while ledger.events and ledger.events[0][0] <= day_cutoff:
+            ts, gas = ledger.events.popleft()
+            ledger.sum_day -= gas
+
+        # Rebuild sum_hour from events that fall within the hour window
+        ledger.sum_hour = 0
+        for ts, gas in ledger.events:
+            if ts > hour_cutoff:
+                ledger.sum_hour += gas
+
+        if ledger.paused and limits is not None:
+            still_exhausted = (
+                (limits.per_hour is not None and ledger.sum_hour >= limits.per_hour)
+                or (limits.per_day is not None and ledger.sum_day >= limits.per_day)
+            )
+            if not still_exhausted:
+                ledger.paused = False
+
+    def _update_pause_state_locked(
+        self, ledger: _WalletLedger, limits: GasLimits
+    ) -> None:
+        """Re-evaluate pause flag after limit changes."""
+        if not ledger.paused:
+            return
+        still_exhausted = (
+            (limits.per_hour is not None and ledger.sum_hour >= limits.per_hour)
+            or (limits.per_day is not None and ledger.sum_day >= limits.per_day)
+        )
+        if not still_exhausted:
+            ledger.paused = False
+
+    def _status_locked(
+        self, wallet: str, ledger: _WalletLedger, limits: GasLimits
+    ) -> BudgetStatus:
+        return BudgetStatus(
+            wallet=wallet,
+            limits=limits,
+            spent_last_hour=ledger.sum_hour,
+            spent_last_day=ledger.sum_day,
+            paused=ledger.paused,
+        )

--- a/switchboard/mpp/session.py
+++ b/switchboard/mpp/session.py
@@ -56,7 +56,7 @@ class ChargeRecord:
 class MPPSession:
     """Client for Tempo's MPP API — open / charge / close sessions.
 
-    Binds spending limits to GasBudgetTracker for unified cap enforcement.
+    Binds spending limits to GasManager for unified cap enforcement.
     """
 
     def __init__(

--- a/switchboard/x402_middleware.py
+++ b/switchboard/x402_middleware.py
@@ -186,7 +186,8 @@ class X402Middleware:
             raise ValueError(f"Recipient {offer.recipient} not in allowlist")
 
         if self.gas_tracker:
-            if not self.gas_tracker.can_send_transaction(offer.amount_wei):
+            wallet = self.payment_client.wallet_address
+            if not self.gas_tracker.can_send_transaction(wallet, offer.amount_wei):
                 raise ValueError("Payment would exceed gas budget")
 
     def _pay_onchain(self, offer: PaymentOffer) -> PaymentProof:
@@ -264,7 +265,8 @@ class X402Middleware:
 
         # Record payment
         if self.gas_tracker:
-            self.gas_tracker.record_gas_usage(offer.amount_wei)
+            wallet = self.payment_client.wallet_address
+            self.gas_tracker.record_gas_usage(wallet, offer.amount_wei)
         self.total_spent_wei += offer.amount_wei
 
         # Retry with payment proof

--- a/tests/test_gas_manager.py
+++ b/tests/test_gas_manager.py
@@ -1,0 +1,425 @@
+"""Tests for switchboard.gas_manager — issue #97 unified GasManager."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from switchboard.gas_manager import (
+    BudgetExhausted,
+    GasManager,
+    GasLimits,
+    SECONDS_PER_DAY,
+    SECONDS_PER_HOUR,
+)
+
+
+class FakeClock:
+    """Deterministic monotonically-controllable clock."""
+
+    def __init__(self, start: float = 1_700_000_000.0):
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+WALLET = "0xAgent"
+
+# ======================================================================
+# GasBudgetTracker compatibility tests
+# ======================================================================
+
+
+class TestGasBudgetCompat:
+
+    def test_default_limits_allow_everything(self):
+        m = GasManager()
+        assert m.can_spend(WALLET, 10**12) is True
+        m.record(WALLET, 10**12)
+        status = m.status(WALLET)
+        assert status.paused is False
+        assert status.remaining_hour is None
+        assert status.remaining_day is None
+
+    def test_record_rejects_negative(self):
+        m = GasManager()
+        with pytest.raises(ValueError):
+            m.record(WALLET, -1)
+        with pytest.raises(ValueError):
+            m.can_spend(WALLET, -1)
+
+    def test_hourly_limit_blocks_overspend(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=100_000), clock=clock)
+        assert m.can_spend(WALLET, 60_000)
+        m.record(WALLET, 60_000)
+        assert m.can_spend(WALLET, 30_000) is True
+        assert m.can_spend(WALLET, 50_000) is False
+
+    def test_hourly_window_rolls_forward_and_auto_unpauses(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=100_000), clock=clock)
+
+        m.record(WALLET, 90_000)
+        assert m.can_spend(WALLET, 20_000) is False  # would exceed
+
+        # Slide past the hour boundary — wallet should auto-unpause.
+        clock.advance(SECONDS_PER_HOUR + 1)
+        assert m.can_spend(WALLET, 90_000) is True
+        # Verify it's no longer paused:
+        assert m.status(WALLET).paused is False
+
+    def test_daily_limit_independent_of_hourly(self):
+        clock = FakeClock()
+        m = GasManager(
+            default_limits=GasLimits(per_hour=50_000, per_day=120_000),
+            clock=clock,
+        )
+
+        for _ in range(3):
+            assert m.can_spend(WALLET, 40_000)
+            m.record(WALLET, 40_000)
+            clock.advance(SECONDS_PER_HOUR + 1)
+            # After window roll, hourly spend evicted — auto-unpaused.
+            # However daily total accumulates.
+            m.resume(WALLET)
+
+        # Day total now 120k == limit exactly; anything more should fail.
+        assert m.can_spend(WALLET, 1) is False
+
+    def test_daily_window_rolls_forward_and_auto_unpauses(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_day=100_000), clock=clock)
+
+        m.record(WALLET, 100_000)
+        assert m.status(WALLET).paused is True
+
+        clock.advance(SECONDS_PER_DAY + 1)
+        assert m.can_spend(WALLET, 100_000) is True
+        assert m.status(WALLET).paused is False
+        assert m.status(WALLET).spent_last_day == 0
+
+    def test_pause_on_exhaustion_blocks_further_spending(self):
+        m = GasManager(default_limits=GasLimits(per_hour=1_000))
+        m.record(WALLET, 1_000)
+        status = m.status(WALLET)
+        assert status.paused is True
+        assert m.can_spend(WALLET, 1) is False
+
+    def test_check_raises_when_exhausted(self):
+        m = GasManager(default_limits=GasLimits(per_hour=500))
+        m.record(WALLET, 500)
+        with pytest.raises(BudgetExhausted) as exc:
+            m.check(WALLET, 1)
+        assert exc.value.args[0].wallet == WALLET
+
+    def test_resume_clears_pause_without_resetting_counters(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=1_000), clock=clock)
+        m.record(WALLET, 1_000)
+        assert m.status(WALLET).paused is True
+
+        m.resume(WALLET)
+        status = m.status(WALLET)
+        assert status.paused is False
+        assert status.spent_last_hour == 1_000  # counters intact
+
+    def test_per_wallet_limits_override_default(self):
+        m = GasManager(default_limits=GasLimits(per_hour=1_000))
+        m.set_limits("0xVIP", GasLimits(per_hour=10_000))
+
+        m.record("0xVIP", 5_000)
+        m.record(WALLET, 900)
+        assert m.status("0xVIP").paused is False
+        assert m.can_spend(WALLET, 500) is False  # default limit binds
+
+    def test_wallets_are_isolated(self):
+        m = GasManager(default_limits=GasLimits(per_hour=1_000))
+        m.record("a", 1_000)
+        assert m.status("a").paused is True
+        assert m.status("b").paused is False
+        assert m.can_spend("b", 999) is True
+
+    def test_reset_clears_history(self):
+        m = GasManager(default_limits=GasLimits(per_hour=100))
+        m.record(WALLET, 100)
+        m.reset(WALLET)
+        s = m.status(WALLET)
+        assert s.spent_last_hour == 0
+        assert s.paused is False
+        assert m.can_spend(WALLET, 100) is True
+
+    def test_thread_safety_sum_is_exact(self):
+        m = GasManager()
+        N = 500
+        workers = 8
+
+        def run():
+            for _ in range(N):
+                m.record(WALLET, 1)
+
+        threads = [threading.Thread(target=run) for _ in range(workers)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert m.status(WALLET).spent_last_hour == N * workers
+
+    def test_status_reports_remaining(self):
+        m = GasManager(default_limits=GasLimits(per_hour=10_000, per_day=100_000))
+        m.record(WALLET, 3_000)
+        s = m.status(WALLET)
+        assert s.remaining_hour == 7_000
+        assert s.remaining_day == 97_000
+
+
+# ======================================================================
+# GasTracker compatibility tests
+# ======================================================================
+
+
+class TestGasTrackerCompat:
+
+    def test_initialization(self):
+        m = GasManager()
+        assert m.get_current_spent("test") == (0, 0)
+        assert m.is_paused("test") is False
+
+    def test_set_limits(self):
+        m = GasManager()
+        m.set_limits("test", GasLimits(per_hour=1000, per_day=5000))
+        assert m.limits_for("test") == GasLimits(per_hour=1000, per_day=5000)
+        assert m.get_current_spent("test") == (0, 0)
+        assert m.is_paused("test") is False
+
+    def test_can_send_transaction_within_limits(self):
+        m = GasManager(default_limits=GasLimits(per_hour=1000, per_day=5000))
+
+        m.record_gas_usage(WALLET, 100)
+        assert m.get_current_spent(WALLET) == (100, 100)
+        assert m.is_paused(WALLET) is False
+        assert m.can_send_transaction(WALLET, 100) is True
+
+        m.record_gas_usage(WALLET, 200)
+        assert m.get_current_spent(WALLET) == (300, 300)
+        assert m.is_paused(WALLET) is False
+        assert m.can_send_transaction(WALLET, 700) is True
+
+    def test_hourly_limit_exceeded(self):
+        m = GasManager(default_limits=GasLimits(per_hour=500, per_day=5000))
+        m.record_gas_usage(WALLET, 300)
+        m.record_gas_usage(WALLET, 200)
+
+        assert m.get_current_spent(WALLET) == (500, 500)
+        assert m.is_paused(WALLET) is True
+        assert m.can_send_transaction(WALLET, 1) is False
+
+        # Recording more gas when paused still updates the counters
+        m.record_gas_usage(WALLET, 50)
+        assert m.get_current_spent(WALLET) == (550, 550)
+        assert m.is_paused(WALLET) is True
+
+    def test_daily_limit_exceeded(self):
+        m = GasManager(default_limits=GasLimits(per_hour=10000, per_day=1000))
+        m.record_gas_usage(WALLET, 500)
+        m.record_gas_usage(WALLET, 500)
+
+        assert m.get_current_spent(WALLET) == (1000, 1000)
+        assert m.is_paused(WALLET) is True
+        assert m.can_send_transaction(WALLET, 1) is False
+
+        m.record_gas_usage(WALLET, 100)
+        assert m.get_current_spent(WALLET) == (1100, 1100)
+        assert m.is_paused(WALLET) is True
+
+    def test_hourly_auto_reset(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=500, per_day=5000), clock=clock)
+
+        m.record_gas_usage(WALLET, 400)
+        assert m.get_current_spent(WALLET) == (400, 400)
+        assert m.is_paused(WALLET) is False
+        assert m.can_send_transaction(WALLET, 100) is True
+
+        # Advance past the hour boundary so the 400 is evicted from hour window
+        clock.advance(SECONDS_PER_HOUR + 1)
+        assert m.get_current_spent(WALLET) == (0, 400)
+        assert m.is_paused(WALLET) is False
+
+        # Use full budget in the new hour
+        m.record_gas_usage(WALLET, 490)
+        assert m.get_current_spent(WALLET) == (490, 890)
+        assert m.is_paused(WALLET) is False  # 490 < 500
+
+        m.record_gas_usage(WALLET, 10)
+        assert m.get_current_spent(WALLET) == (500, 900)
+        assert m.is_paused(WALLET) is True
+
+    def test_daily_auto_reset(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=1000, per_day=1000), clock=clock)
+
+        m.record_gas_usage(WALLET, 700)
+        assert m.get_current_spent(WALLET) == (700, 700)
+        assert m.is_paused(WALLET) is False
+
+        # Advance past the day boundary — the 700 is evicted from both windows
+        clock.advance(SECONDS_PER_DAY + 1)
+        assert m.get_current_spent(WALLET) == (0, 0)
+        assert m.is_paused(WALLET) is False
+
+        # Use budget in new day
+        m.record_gas_usage(WALLET, 300)
+        assert m.get_current_spent(WALLET) == (300, 300)
+
+        m.record_gas_usage(WALLET, 700)
+        assert m.get_current_spent(WALLET) == (1000, 1000)
+        assert m.is_paused(WALLET) is True
+
+    def test_auto_unpause_after_reset(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=100, per_day=200), clock=clock)
+
+        m.record_gas_usage(WALLET, 100)
+        assert m.is_paused(WALLET) is True
+        assert m.can_send_transaction(WALLET, 1) is False
+
+        # Advance past hour boundary
+        clock.advance(SECONDS_PER_HOUR + 1)
+        # Auto-unpaused
+        assert m.can_send_transaction(WALLET, 10) is True
+        assert m.is_paused(WALLET) is False
+        assert m.get_current_spent(WALLET) == (0, 100)
+
+        # Hit hourly limit again
+        m.record_gas_usage(WALLET, 10)
+        m.record_gas_usage(WALLET, 90)
+        assert m.is_paused(WALLET) is True
+
+        # Advance past day boundary — both reset
+        clock.advance(SECONDS_PER_DAY + 1)
+        assert m.can_send_transaction(WALLET, 10) is True
+        assert m.is_paused(WALLET) is False
+        assert m.get_current_spent(WALLET) == (0, 0)
+
+    def test_limits_change_unpauses(self):
+        m = GasManager(default_limits=GasLimits(per_hour=100, per_day=200))
+        m.record_gas_usage(WALLET, 100)
+        assert m.is_paused(WALLET) is True
+
+        m.set_limits(WALLET, GasLimits(per_hour=200, per_day=300))
+        assert m.is_paused(WALLET) is False
+        assert m.get_current_spent(WALLET) == (100, 100)
+        assert m.can_send_transaction(WALLET, 50) is True
+
+    def test_no_limits_default(self):
+        m = GasManager()
+        m.record_gas_usage(WALLET, 1_000_000)
+        assert m.get_current_spent(WALLET) == (1_000_000, 1_000_000)
+        assert m.is_paused(WALLET) is False
+        assert m.can_send_transaction(WALLET, 1_000_000_000) is True
+
+    def test_reset_all(self):
+        m = GasManager(default_limits=GasLimits(per_hour=100))
+        m.record_gas_usage("a", 99)
+        m.record_gas_usage("b", 99)
+        assert m.is_paused("a") is False
+        assert m.is_paused("b") is False
+
+        m.record_gas_usage("a", 1)
+        assert m.is_paused("a") is True
+
+        m.reset_all()
+        assert m.get_current_spent("a") == (0, 0)
+        assert m.is_paused("a") is False
+        assert m.get_current_spent("b") == (0, 0)
+
+    def test_singleton_not_required(self):
+        """GasManager is NOT a singleton — unlike GasTracker.
+        This is by design: each component manages its own budget."""
+        m1 = GasManager(default_limits=GasLimits(per_hour=100))
+        m2 = GasManager(default_limits=GasLimits(per_hour=200))
+        assert m1 is not m2
+        m1.record_gas_usage(WALLET, 50)
+        assert m2.get_current_spent(WALLET) == (0, 0)
+
+
+# ======================================================================
+# Unified GasManager-specific tests
+# ======================================================================
+
+
+class TestGasManager:
+
+    def test_auto_unpause_characteristic(self):
+        """Core characteristic of the unified manager: auto-unpause when
+        rolling windows free up capacity (from GasTracker)."""
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=100), clock=clock)
+
+        m.record(WALLET, 100)
+        status = m.status(WALLET)
+        assert status.paused is True
+        # Without explicit resume(), the wallet stays paused
+        assert m.can_spend(WALLET, 1) is False
+
+        # After window rollover, auto-unpauses
+        clock.advance(SECONDS_PER_HOUR + 1)
+        assert m.can_spend(WALLET, 50) is True
+        assert m.status(WALLET).paused is False
+
+    def test_both_api_styles_equivalent(self):
+        """can_spend/check/record == can_send_transaction/record_gas_usage."""
+        clock = FakeClock()
+        m1 = GasManager(default_limits=GasLimits(per_hour=1000), clock=clock)
+        m2 = GasManager(default_limits=GasLimits(per_hour=1000), clock=clock)
+
+        # Both APIs should produce equivalent results
+        assert m1.can_spend(WALLET, 500) == m2.can_send_transaction(WALLET, 500)
+        m1.record(WALLET, 500)
+        m2.record_gas_usage(WALLET, 500)
+        assert m1.status(WALLET) == m2.status(WALLET)
+
+    def test_pause_on_hit_release_on_set_limits(self):
+        m = GasManager(default_limits=GasLimits(per_hour=100))
+        m.record(WALLET, 100)
+        assert m.is_paused(WALLET) is True
+
+        # Raising the limit should unpause
+        m.set_limits(WALLET, GasLimits(per_hour=200))
+        assert m.is_paused(WALLET) is False
+
+    def test_pause_stays_if_new_limits_still_exceeded(self):
+        m = GasManager(default_limits=GasLimits(per_hour=100))
+        m.record(WALLET, 150)
+        assert m.is_paused(WALLET) is True
+
+        # New limit still below current spend
+        m.set_limits(WALLET, GasLimits(per_hour=120))
+        assert m.is_paused(WALLET) is True
+
+    def test_evict_respects_hourly_boundary(self):
+        clock = FakeClock()
+        m = GasManager(default_limits=GasLimits(per_hour=1000), clock=clock)
+
+        # Old spend that falls outside the hour window should be evicted
+        m.record(WALLET, 900)
+        clock.advance(SECONDS_PER_HOUR + 1)
+        m.record(WALLET, 100)
+
+        s = m.status(WALLET)
+        assert s.spent_last_hour == 100
+        assert s.spent_last_day == 1000
+
+    def test_check_raises_budget_exhausted_with_status(self):
+        m = GasManager(default_limits=GasLimits(per_hour=100))
+        m.record(WALLET, 100)
+        with pytest.raises(BudgetExhausted) as exc:
+            m.check(WALLET, 1)
+        assert isinstance(exc.value.args[0], m.status(WALLET).__class__)


### PR DESCRIPTION
## Summary

Unifies `gas_budget.py` (`GasBudgetTracker`) and `gas_tracker.py` (`GasTracker`) into a single `GasManager` class, resolving the duplicate gas-budget implementations.

### Design
- **Per-wallet tracking** (from GasBudgetTracker) — each wallet has independent counters
- **Rolling-window enforcement** (from GasBudgetTracker) — deque-based, not calendar buckets
- **Auto-unpause** (from GasTracker) — windows that free up capacity automatically unpause
- **Thread-safe** with injectable clock for deterministic testing
- **Dual API** — supports both `GasBudgetTracker`-style (`can_spend`/`check`/`record`) and `GasTracker`-style (`can_send_transaction`/`record_gas_usage`/`is_paused`/`get_current_spent`) interfaces

### Changes
| File | Change |
|------|--------|
| `switchboard/gas_manager.py` | **New** — unified `GasManager`, `GasLimits`, `BudgetStatus`, `BudgetExhausted` |
| `tests/test_gas_manager.py` | **New** — 32 tests covering both API styles |
| `switchboard/__init__.py` | Export `GasManager`, `GasLimits`, `BudgetStatus`, `BudgetExhausted` |
| `switchboard/x402_middleware.py` | Updated to pass wallet address to GasManager API |
| `switchboard/mpp/session.py` | Updated docstring to reference GasManager |

### Backward Compatibility
All existing tests pass unchanged. The old modules (`gas_budget.py`, `gas_tracker.py`) remain importable.

Closes #97