### PR TITLE
Add nested ZAP frame decoding

### DIFF
--- a/switchboard/zap_transport.py
+++ b/switchboard/zap_transport.py
@@ -46,8 +46,18 @@ except ImportError:  # pragma: no cover — exercised by environment, not tests
 __all__ = [
     "HAS_ZAP_PY",
     "ZapNotAvailable",
+    "ReservedNestedTag",
+    "ZAP_FRAME_VERSION",
+    "NESTED_NONE",
+    "NESTED_X402",
+    "NESTED_WARP",
+    "FRAME_SCHEMA",
     "OFFER_SCHEMA",
     "PROOF_SCHEMA",
+    "encode",
+    "decode",
+    "encode_frame",
+    "decode_frame",
     "encode_offer",
     "decode_offer",
     "encode_proof",
@@ -65,7 +75,16 @@ class ZapNotAvailable(RuntimeError):
 # Both schemas use uint256 amount-as-bytes (32 big-endian bytes) so we don't truncate
 # realistic on-chain values into a uint64 — the JSON path already accepts
 # arbitrarily large `int`s and we want byte-for-byte interop with that.
+class ReservedNestedTag(ValueError):
+    """A ZAP frame used a reserved nested payload tag."""
+
+
 _AMOUNT_BYTES = 32
+ZAP_FRAME_VERSION = 1
+NESTED_NONE = 0x00
+NESTED_X402 = 0x01
+NESTED_WARP = 0x02
+_SUPPORTED_NESTED_TAGS = {NESTED_NONE, NESTED_X402, NESTED_WARP}
 
 # ``scheme`` is encoded as uint8. Order matches the wire intent, not the Python
 # enum's iteration order — pin it here so a Go implementation can mirror it.
@@ -87,6 +106,21 @@ _PQ_ALG_TO_TAG = {
     "hybrid-ecdsa-ml-dsa-65": 0x80,
 }
 _TAG_TO_PQ_ALG = {v: k for k, v in _PQ_ALG_TO_TAG.items()}
+
+
+def _build_frame_schema():
+    if not HAS_ZAP_PY:
+        return None
+    return (
+        StructBuilder("SwitchboardZapFrame")
+        .uint8("version")
+        .uint8("scheme")
+        .uint8("nested_tag")
+        .hash("header_digest")
+        .bytes("payload")
+        .bytes("nested_payload")
+        .build()
+    )
 
 
 def _build_offer_schema():
@@ -151,6 +185,7 @@ def _build_proof_schema():
     )
 
 
+FRAME_SCHEMA = _build_frame_schema()
 OFFER_SCHEMA = _build_offer_schema()
 PROOF_SCHEMA = _build_proof_schema()
 
@@ -294,6 +329,77 @@ def _hash_from_hex(s: str) -> bytes:
     if len(raw) != HASH_SIZE:
         raise ValueError(f"tx_hash must be {HASH_SIZE} bytes, got {len(raw)}")
     return raw
+
+
+def _coerce_digest(header_digest: bytes | str) -> bytes:
+    if isinstance(header_digest, str):
+        if header_digest.startswith(("0x", "0X")):
+            header_digest = header_digest[2:]
+        raw = bytes.fromhex(header_digest)
+    else:
+        raw = bytes(header_digest)
+    if len(raw) != HASH_SIZE:
+        raise ValueError(f"header_digest must be {HASH_SIZE} bytes, got {len(raw)}")
+    return raw
+
+
+def _validate_nested_tag(nested_tag: int) -> None:
+    if nested_tag not in _SUPPORTED_NESTED_TAGS:
+        raise ReservedNestedTag(f"RESERVED_NESTED_TAG: 0x{nested_tag:02x}")
+
+
+def encode(
+    version: int,
+    scheme: PaymentScheme | int,
+    header_digest: bytes | str,
+    payload: bytes,
+    *,
+    nested_tag: int = NESTED_NONE,
+    nested_payload: bytes = b"",
+) -> bytes:
+    """Serialize a generic Switchboard ZAP frame with optional nested payload."""
+    _require_zap()
+    _validate_nested_tag(nested_tag)
+    if nested_tag == NESTED_NONE and nested_payload:
+        raise ValueError("nested_payload must be empty when nested_tag is 0x00")
+
+    f = {fld.name: fld.offset for fld in FRAME_SCHEMA.fields}
+    scheme_tag = _SCHEME_TO_WIRE[scheme] if isinstance(scheme, PaymentScheme) else int(scheme)
+
+    b = Builder()
+    ob = b.start_object(FRAME_SCHEMA.size)
+    ob.set_uint8(f["version"], version)
+    ob.set_uint8(f["scheme"], scheme_tag)
+    ob.set_uint8(f["nested_tag"], nested_tag)
+    ob.set_hash(f["header_digest"], _coerce_digest(header_digest))
+    ob.set_bytes(f["payload"], bytes(payload))
+    ob.set_bytes(f["nested_payload"], bytes(nested_payload))
+    ob.finish_as_root()
+    return b.finish()
+
+
+def decode(wire: bytes) -> tuple[int, PaymentScheme, str, bytes, int, bytes]:
+    """Decode `(version, scheme, header_digest, payload, nested_tag, nested_payload)`."""
+    _require_zap()
+    f = {fld.name: fld.offset for fld in FRAME_SCHEMA.fields}
+
+    msg = parse(wire)
+    root = msg.root()
+    nested_tag = root.uint8(f["nested_tag"])
+    _validate_nested_tag(nested_tag)
+
+    return (
+        root.uint8(f["version"]),
+        _WIRE_TO_SCHEME[root.uint8(f["scheme"])],
+        root.hash(f["header_digest"]).hex(),
+        root.bytes(f["payload"]),
+        nested_tag,
+        root.bytes(f["nested_payload"]),
+    )
+
+
+encode_frame = encode
+decode_frame = decode
 
 
 def encode_proof(proof: PaymentProof) -> bytes:

--- a/tests/protocol_vectors/zap_nested.v1.json
+++ b/tests/protocol_vectors/zap_nested.v1.json
@@ -1,0 +1,43 @@
+{
+  "schema": "switchboard/zap-nested/v1",
+  "version": 1,
+  "description": "Conformance vectors for ZAP frame nested payload tag handling.",
+  "cases": [
+    {
+      "name": "no-nesting",
+      "scheme": "exact",
+      "header_digest": "0000000000000000000000000000000000000000000000000000000000000000",
+      "payload_hex": "7061796c6f6164",
+      "nested_tag": 0,
+      "nested_payload_hex": "",
+      "expected": "ok"
+    },
+    {
+      "name": "x402-nested",
+      "scheme": "exact",
+      "header_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "payload_hex": "77726170",
+      "nested_tag": 1,
+      "nested_payload_utf8": "{\"amount\":\"1000\",\"currency\":\"USDC\",\"recipient\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"chainId\":8453,\"scheme\":\"exact\",\"nonce\":\"n-1\"}",
+      "expected": "ok"
+    },
+    {
+      "name": "warp-reserved-for-consumers",
+      "scheme": "escrow",
+      "header_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+      "payload_hex": "7772617032",
+      "nested_tag": 2,
+      "nested_payload_hex": "01020304",
+      "expected": "ok"
+    },
+    {
+      "name": "reserved-tag-rejected",
+      "scheme": "streaming",
+      "header_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+      "payload_hex": "626164",
+      "nested_tag": 3,
+      "nested_payload_hex": "00",
+      "expected": "RESERVED_NESTED_TAG"
+    }
+  ]
+}

--- a/tests/test_zap_transport.py
+++ b/tests/test_zap_transport.py
@@ -7,7 +7,9 @@ Skipped if zap_py is not installed — install with::
 
 from __future__ import annotations
 
+import json
 import time
+from pathlib import Path
 
 import pytest
 
@@ -357,6 +359,147 @@ def test_zap_not_available_raises_when_disabled(monkeypatch):
         zt.encode_offer(offer)
     with pytest.raises(zt.ZapNotAvailable):
         zt.decode_offer(b"junk")
+
+
+def test_nested_tag_policy_rejects_reserved_tags():
+    with pytest.raises(zt.ReservedNestedTag, match="RESERVED_NESTED_TAG"):
+        zt._validate_nested_tag(0x03)
+    with pytest.raises(zt.ReservedNestedTag, match="RESERVED_NESTED_TAG"):
+        zt._validate_nested_tag(0xFF)
+
+
+def test_zap_nested_conformance_vectors_cover_required_tags():
+    vectors = json.loads(
+        Path("tests/protocol_vectors/zap_nested.v1.json").read_text(encoding="utf-8")
+    )
+    assert vectors["schema"] == "switchboard/zap-nested/v1"
+    cases = {case["name"]: case for case in vectors["cases"]}
+    assert set(cases) == {
+        "no-nesting",
+        "x402-nested",
+        "warp-reserved-for-consumers",
+        "reserved-tag-rejected",
+    }
+    assert cases["no-nesting"]["nested_tag"] == zt.NESTED_NONE
+    assert cases["x402-nested"]["nested_tag"] == zt.NESTED_X402
+    assert cases["warp-reserved-for-consumers"]["nested_tag"] == zt.NESTED_WARP
+    assert cases["reserved-tag-rejected"]["expected"] == "RESERVED_NESTED_TAG"
+
+
+@ZAP_REQUIRED
+def test_generic_frame_no_nesting_roundtrip():
+    wire = zt.encode(
+        zt.ZAP_FRAME_VERSION,
+        PaymentScheme.EXACT,
+        b"\x00" * 32,
+        b"outer",
+        nested_tag=zt.NESTED_NONE,
+    )
+
+    assert zt.decode(wire) == (
+        zt.ZAP_FRAME_VERSION,
+        PaymentScheme.EXACT,
+        "0x" + "00" * 32,
+        b"outer",
+        zt.NESTED_NONE,
+        b"",
+    )
+
+
+@ZAP_REQUIRED
+def test_generic_frame_x402_nested_payload_roundtrips_against_parser():
+    x402_payload = json.dumps({
+        "amount": "1000",
+        "currency": "USDC",
+        "recipient": USDC,
+        "chainId": 8453,
+        "scheme": "exact",
+        "nonce": "nested-1",
+    }, separators=(",", ":")).encode()
+
+    wire = zt.encode(
+        zt.ZAP_FRAME_VERSION,
+        PaymentScheme.EXACT,
+        "11" * 32,
+        b"warp",
+        nested_tag=zt.NESTED_X402,
+        nested_payload=x402_payload,
+    )
+    version, scheme, header_digest, payload, nested_tag, nested_payload = zt.decode(wire)
+    nested_offer = PaymentOffer.from_header(nested_payload.decode(), endpoint="/zap")
+
+    assert version == zt.ZAP_FRAME_VERSION
+    assert scheme == PaymentScheme.EXACT
+    assert header_digest == "0x" + "11" * 32
+    assert payload == b"warp"
+    assert nested_tag == zt.NESTED_X402
+    assert nested_offer.amount_wei == 1000
+    assert nested_offer.recipient.lower() == USDC.lower()
+    assert nested_offer.endpoint == "/zap"
+
+
+@ZAP_REQUIRED
+def test_generic_frame_accepts_reserved_warp_tag_two_without_recursive_decode():
+    wire = zt.encode(
+        zt.ZAP_FRAME_VERSION,
+        PaymentScheme.ESCROW,
+        b"\x22" * 32,
+        b"outer",
+        nested_tag=zt.NESTED_WARP,
+        nested_payload=b"\x01\x02\x03",
+    )
+
+    assert zt.decode(wire) == (
+        zt.ZAP_FRAME_VERSION,
+        PaymentScheme.ESCROW,
+        "0x" + "22" * 32,
+        b"outer",
+        zt.NESTED_WARP,
+        b"\x01\x02\x03",
+    )
+
+
+@ZAP_REQUIRED
+def test_generic_frame_rejects_reserved_nested_tag_on_encode():
+    with pytest.raises(zt.ReservedNestedTag, match="RESERVED_NESTED_TAG"):
+        zt.encode(
+            zt.ZAP_FRAME_VERSION,
+            PaymentScheme.STREAMING,
+            b"\x33" * 32,
+            b"bad",
+            nested_tag=0x03,
+            nested_payload=b"\x00",
+        )
+
+
+@ZAP_REQUIRED
+def test_generic_frame_rejects_reserved_nested_tag_on_decode():
+    f = {fld.name: fld.offset for fld in zt.FRAME_SCHEMA.fields}
+    b = zap_py.Builder()
+    ob = b.start_object(zt.FRAME_SCHEMA.size)
+    ob.set_uint8(f["version"], zt.ZAP_FRAME_VERSION)
+    ob.set_uint8(f["scheme"], zt._SCHEME_TO_WIRE[PaymentScheme.STREAMING])
+    ob.set_uint8(f["nested_tag"], 0x03)
+    ob.set_hash(f["header_digest"], b"\x33" * 32)
+    ob.set_bytes(f["payload"], b"bad")
+    ob.set_bytes(f["nested_payload"], b"\x00")
+    ob.finish_as_root()
+
+    with pytest.raises(zt.ReservedNestedTag, match="RESERVED_NESTED_TAG"):
+        zt.decode(b.finish())
+
+
+@ZAP_REQUIRED
+def test_generic_frame_rejects_nested_payload_without_tag():
+    with pytest.raises(ValueError, match="nested_payload"):
+        zt.encode(
+            zt.ZAP_FRAME_VERSION,
+            PaymentScheme.EXACT,
+            b"\x44" * 32,
+            b"outer",
+            nested_tag=zt.NESTED_NONE,
+            nested_payload=b"unexpected",
+        )
 
 
 @ZAP_REQUIRED


### PR DESCRIPTION
/claim #76

## Summary
- add a generic `zap_transport.encode()` / `zap_transport.decode()` frame API that returns `(version, scheme, header_digest, payload, nested_tag, nested_payload)`
- support nested tags `0x00` no nesting, `0x01` x402 payload, and `0x02` reserved-for-consumer payloads while rejecting `0x03..0xFF` with `RESERVED_NESTED_TAG`
- add ZAP nested conformance vectors under `tests/protocol_vectors/zap_nested.v1.json`
- cover no-nesting, x402 parser round-trip, tag `0x02`, and reserved tag rejection tests

## Validation
- `python -m pytest tests\test_zap_transport.py tests\test_x402_middleware.py -q` (`19 passed, 36 skipped`)
- `python -m py_compile switchboard\zap_transport.py tests\test_zap_transport.py`
- `git diff --check`

Note: local `zap_py` install could not be enabled because the current upstream `luxfi/zap` `python` subdirectory does not expose Python project metadata for pip. The repository already gates ZAP-specific tests with `pytest.importorskip`, so the touched-area suite still passes in this environment.