### PR TITLE
Track signature algorithms in nonce manager

### DIFF
--- a/switchboard/nonce_manager.py
+++ b/switchboard/nonce_manager.py
@@ -1,12 +1,47 @@
 import threading
+from dataclasses import dataclass
 from sortedcontainers import SortedSet
-from typing import Dict, Any, Optional, Callable, Protocol
+from typing import Any, Callable, Dict, Optional, Protocol, Tuple
+
+
+DEFAULT_CHAIN_ID = 0
+
+SIGNATURE_ALG_ECDSA = 0x01
+SIGNATURE_ALG_ML_DSA_65 = 0x02
+SIGNATURE_ALG_HYBRID = 0x03
+
+_SUPPORTED_SIGNATURE_ALGS = {
+    SIGNATURE_ALG_ECDSA,
+    SIGNATURE_ALG_ML_DSA_65,
+    SIGNATURE_ALG_HYBRID,
+}
+
+
+class UnsupportedSignatureAlgorithm(ValueError):
+    """Raised when a nonce is requested for an unknown signature algorithm tag."""
+
+
+class HybridSignatureAlgorithmReserved(UnsupportedSignatureAlgorithm):
+    """Raised when hybrid signatures are requested without the feature flag."""
+
+
+class SignatureAlgorithmMismatch(ValueError):
+    """Raised when a nonce would be re-signed under a different algorithm tag."""
+
+
+@dataclass(frozen=True)
+class NonceRecord:
+    nonce: int
+    signature_alg: int
+    transaction: Optional[Any] = None
+
 
 class ChainClient(Protocol):
     """
     Protocol for a blockchain client that provides nonce data.
     A concrete implementation would interact with a specific blockchain (e.g., Ethereum RPC).
     """
+
     def get_current_onchain_nonce(self, address: str) -> int:
         """
         Fetches the current transaction count (nonce) for an address on the blockchain.
@@ -15,12 +50,14 @@ class ChainClient(Protocol):
         """
         ...
 
+
 class WalletState:
     """
-    Manages the local nonce state for a single wallet address.
+    Manages the local nonce state for a single wallet address on one chain.
     """
+
     def __init__(self, confirmed_nonce: int):
-        # The highest sequentially confirmed nonce known to the manager.
+        # The next sequential nonce known to be valid by the manager.
         self.confirmed_nonce: int = confirmed_nonce
 
         # Stores nonces that have been acquired by the manager but not yet confirmed on-chain.
@@ -31,9 +68,23 @@ class WalletState:
         # This allows re-queuing of transactions if a reorg invalidates their nonces.
         self.pending_transactions: Dict[int, Any] = {}
 
+        # Every pending nonce has a record carrying the signature algorithm used
+        # to sign it. Existing in-memory records are migrated to ECDSA on read.
+        self.pending_records: Dict[int, NonceRecord] = {}
+
+        # Signature algorithms for transactions that were confirmed locally.
+        # If a reorg rolls them back, the manager can prevent a different
+        # algorithm from re-signing the same nonce by accident.
+        self.confirmed_signature_algs: Dict[int, int] = {}
+
+        # Signature algorithms for nonces that need rebroadcast after a reorg or
+        # stale-pending cleanup.
+        self.rebroadcast_signature_algs: Dict[int, int] = {}
+
         # Nonces confirmed out-of-order (ahead of confirmed_nonce). They roll into
         # confirmed_nonce when the gap fills.
         self.out_of_order_confirmations: set = set()
+
 
 class NonceManager:
     """
@@ -43,7 +94,13 @@ class NonceManager:
     It ensures nonces are always valid and correctly ordered, even when
     concurrent transactions are being sent or chain reorganizations occur.
     """
-    def __init__(self, chain_client: ChainClient, re_queue_callback: Optional[Callable[[Any], None]] = None):
+
+    def __init__(
+        self,
+        chain_client: ChainClient,
+        re_queue_callback: Optional[Callable[[Any], None]] = None,
+        allow_hybrid: bool = False,
+    ):
         """
         Initializes the NonceManager.
 
@@ -53,22 +110,75 @@ class NonceManager:
             re_queue_callback: An optional callback function to be invoked when
                                transactions need to be re-queued due to a reorg.
                                It should accept a single argument: the original transaction object.
+            allow_hybrid: Feature flag for reserving hybrid signature-algorithm
+                          nonces. Hybrid signing/verification is intentionally
+                          not implemented here.
         """
         self._chain_client: ChainClient = chain_client
-        self._wallet_states: Dict[str, WalletState] = {}
-        self._lock = threading.Lock() # Protects access to _wallet_states for thread safety
+        self._wallet_states: Dict[Tuple[int, str], WalletState] = {}
+        self._lock = threading.Lock()  # Protects access to _wallet_states for thread safety
         self._re_queue_callback = re_queue_callback
+        self._allow_hybrid = allow_hybrid
 
-    def _get_wallet_state(self, address: str) -> WalletState:
+    def _wallet_key(self, chain_id: int, address: str) -> Tuple[int, str]:
+        return (chain_id, address)
+
+    def _get_wallet_state(self, address: str, chain_id: int = DEFAULT_CHAIN_ID) -> WalletState:
         """
         Retrieves or initializes the WalletState for a given address.
         This method must be called under the `_lock` to ensure thread safety.
         """
-        if address not in self._wallet_states:
+        key = self._wallet_key(chain_id, address)
+        if key not in self._wallet_states:
             # For a new wallet, fetch its current on-chain nonce to initialize.
             onchain_nonce = self._chain_client.get_current_onchain_nonce(address)
-            self._wallet_states[address] = WalletState(onchain_nonce)
-        return self._wallet_states[address]
+            self._wallet_states[key] = WalletState(onchain_nonce)
+        return self._wallet_states[key]
+
+    def _validate_signature_alg(self, signature_alg: int) -> None:
+        if signature_alg not in _SUPPORTED_SIGNATURE_ALGS:
+            raise UnsupportedSignatureAlgorithm(
+                f"UNSUPPORTED_SIGNATURE_ALG: unknown signature_alg 0x{signature_alg:02x}"
+            )
+
+        if signature_alg == SIGNATURE_ALG_HYBRID and not self._allow_hybrid:
+            raise HybridSignatureAlgorithmReserved(
+                "HYBRID_SIGNATURE_ALG_RESERVED: enable allow_hybrid to reserve hybrid nonces"
+            )
+
+    def _ensure_pending_records(self, state: WalletState) -> None:
+        for nonce in list(state.pending_nonces):
+            if nonce not in state.pending_records:
+                state.pending_records[nonce] = NonceRecord(
+                    nonce=nonce,
+                    signature_alg=SIGNATURE_ALG_ECDSA,
+                    transaction=state.pending_transactions.get(nonce),
+                )
+
+    def _drop_pending_nonce(self, state: WalletState, nonce: int) -> Optional[NonceRecord]:
+        record = state.pending_records.pop(nonce, None)
+        if nonce in state.pending_nonces:
+            state.pending_nonces.remove(nonce)
+        state.pending_transactions.pop(nonce, None)
+        return record
+
+    def _assert_rebroadcast_alg(
+        self,
+        state: WalletState,
+        nonce: int,
+        signature_alg: int,
+        force_rebroadcast_alg: bool,
+    ) -> None:
+        original_alg = state.rebroadcast_signature_algs.get(nonce)
+        if original_alg is None:
+            return
+
+        if original_alg != signature_alg and not force_rebroadcast_alg:
+            raise SignatureAlgorithmMismatch(
+                "SIGNATURE_ALG_MISMATCH: nonce "
+                f"{nonce} was previously signed with 0x{original_alg:02x}, "
+                f"refusing to rebroadcast with 0x{signature_alg:02x}"
+            )
 
     def _sync_with_onchain_nonce(self, state: WalletState, address: str):
         """
@@ -78,17 +188,22 @@ class NonceManager:
         This method must be called under the `_lock`.
         """
         onchain_nonce = self._chain_client.get_current_onchain_nonce(address)
+        self._ensure_pending_records(state)
 
         if onchain_nonce > state.confirmed_nonce:
             # The on-chain nonce is higher than our locally confirmed nonce.
             # Pending nonces strictly less than onchain_nonce are confirmed; pending nonces
-            # equal to onchain_nonce are stale (the chain advanced past them without including
-            # our tx) and should be re-issued on the next acquire.
+            # equal to onchain_nonce are stale and should be re-issued on the next acquire.
             nonces_to_remove = SortedSet(n for n in state.pending_nonces if n <= onchain_nonce)
             for n in nonces_to_remove:
-                state.pending_nonces.remove(n)
-                if n in state.pending_transactions:
-                    del state.pending_transactions[n]
+                record = self._drop_pending_nonce(state, n)
+                if record is None:
+                    continue
+
+                if n < onchain_nonce:
+                    state.confirmed_signature_algs[n] = record.signature_alg
+                else:
+                    state.rebroadcast_signature_algs[n] = record.signature_alg
 
             # Out-of-order confirmations the chain has now subsumed are no longer interesting.
             state.out_of_order_confirmations = {
@@ -98,7 +213,85 @@ class NonceManager:
             # Update our locally tracked confirmed_nonce to reflect the latest on-chain state.
             state.confirmed_nonce = onchain_nonce
 
-    def acquire_nonce(self, address: str, transaction: Optional[Any] = None) -> int:
+    def _reserve_next_nonce(
+        self,
+        state: WalletState,
+        signature_alg: int,
+        transaction: Optional[Any],
+        force_rebroadcast_alg: bool,
+    ) -> int:
+        self._ensure_pending_records(state)
+
+        # Determine the next available nonce: the lowest nonce at or above
+        # `confirmed_nonce` that is not already pending. Walking up from
+        # `confirmed_nonce` (rather than taking ``max(pending) + 1``) means a
+        # nonce freed by `release_nonce` or a gap left by an out-of-order
+        # confirmation is reused before the sequence is extended. Ethereum
+        # requires gapless nonces, so leaving a hole would stall every
+        # higher-nonce pending tx until the gap is filled.
+        next_nonce = state.confirmed_nonce
+        for pending in state.pending_nonces.irange(minimum=next_nonce):
+            if pending != next_nonce:
+                break
+            next_nonce += 1
+
+        self._assert_rebroadcast_alg(
+            state,
+            next_nonce,
+            signature_alg,
+            force_rebroadcast_alg,
+        )
+
+        # Add the chosen nonce to the set of pending nonces.
+        state.pending_nonces.add(next_nonce)
+        state.pending_records[next_nonce] = NonceRecord(
+            nonce=next_nonce,
+            signature_alg=signature_alg,
+            transaction=transaction,
+        )
+        state.rebroadcast_signature_algs.pop(next_nonce, None)
+        if transaction is not None:
+            state.pending_transactions[next_nonce] = transaction
+        return next_nonce
+
+    def next_nonce(
+        self,
+        chain_id: int,
+        address: str,
+        alg: int,
+        transaction: Optional[Any] = None,
+        *,
+        force_rebroadcast_alg: bool = False,
+    ) -> int:
+        """
+        Atomically reserves the next available nonce for (chain_id, address)
+        under the supplied signature algorithm tag.
+
+        If a prior reorg or stale-pending cleanup requires this nonce to be
+        rebroadcast, the algorithm must match unless `force_rebroadcast_alg` is
+        explicitly set by the operator.
+        """
+        self._validate_signature_alg(alg)
+
+        with self._lock:
+            state = self._get_wallet_state(address, chain_id)
+            self._sync_with_onchain_nonce(state, address)
+            return self._reserve_next_nonce(
+                state,
+                alg,
+                transaction,
+                force_rebroadcast_alg,
+            )
+
+    def acquire_nonce(
+        self,
+        address: str,
+        transaction: Optional[Any] = None,
+        signature_alg: int = SIGNATURE_ALG_ECDSA,
+        *,
+        chain_id: int = DEFAULT_CHAIN_ID,
+        force_rebroadcast_alg: bool = False,
+    ) -> int:
         """
         Acquires the next available nonce for a given wallet address.
         The acquired nonce is marked as 'pending' and associated with a transaction.
@@ -112,32 +305,15 @@ class NonceManager:
         Returns:
             The integer value of the acquired nonce.
         """
-        with self._lock:
-            state = self._get_wallet_state(address)
-            
-            # First, ensure our local state is synchronized with the latest on-chain nonce.
-            self._sync_with_onchain_nonce(state, address)
+        return self.next_nonce(
+            chain_id,
+            address,
+            signature_alg,
+            transaction,
+            force_rebroadcast_alg=force_rebroadcast_alg,
+        )
 
-            # Determine the next available nonce: the lowest nonce at or above
-            # `confirmed_nonce` that is not already pending. Walking up from
-            # `confirmed_nonce` (rather than taking ``max(pending) + 1``) means a
-            # nonce freed by `release_nonce` — or a gap left by an out-of-order
-            # confirmation — is reused before the sequence is extended. Ethereum
-            # requires gapless nonces, so leaving a hole would stall every
-            # higher-nonce pending tx until the gap is filled.
-            next_nonce = state.confirmed_nonce
-            for pending in state.pending_nonces.irange(minimum=next_nonce):
-                if pending != next_nonce:
-                    break
-                next_nonce += 1
-
-            # Add the chosen nonce to the set of pending nonces.
-            state.pending_nonces.add(next_nonce)
-            if transaction is not None:
-                state.pending_transactions[next_nonce] = transaction
-            return next_nonce
-
-    def release_nonce(self, address: str, nonce: int):
+    def release_nonce(self, address: str, nonce: int, *, chain_id: int = DEFAULT_CHAIN_ID):
         """
         Releases a previously acquired nonce, making it available again.
         This is typically used if a transaction using this nonce failed locally
@@ -150,14 +326,13 @@ class NonceManager:
             nonce: The nonce to release.
         """
         with self._lock:
-            state = self._get_wallet_state(address)
+            state = self._get_wallet_state(address, chain_id)
+            self._ensure_pending_records(state)
             if nonce in state.pending_nonces:
-                state.pending_nonces.remove(nonce)
-                if nonce in state.pending_transactions:
-                    del state.pending_transactions[nonce]
+                self._drop_pending_nonce(state, nonce)
             # Optionally, log a warning if the nonce was not found in pending_nonces.
 
-    def confirm_nonce(self, address: str, nonce: int):
+    def confirm_nonce(self, address: str, nonce: int, *, chain_id: int = DEFAULT_CHAIN_ID):
         """
         Marks a nonce as successfully confirmed on the blockchain (i.e., the transaction
         using it has been mined into a block).
@@ -170,13 +345,14 @@ class NonceManager:
             nonce: The nonce to confirm.
         """
         with self._lock:
-            state = self._get_wallet_state(address)
+            state = self._get_wallet_state(address, chain_id)
+            self._ensure_pending_records(state)
 
             # If the nonce is currently pending, drop it from pending tracking.
             if nonce in state.pending_nonces:
-                state.pending_nonces.remove(nonce)
-                if nonce in state.pending_transactions:
-                    del state.pending_transactions[nonce]
+                record = self._drop_pending_nonce(state, nonce)
+                if record is not None:
+                    state.confirmed_signature_algs[nonce] = record.signature_alg
 
             if nonce < state.confirmed_nonce:
                 # Already counted (e.g., via prior sync).
@@ -193,7 +369,7 @@ class NonceManager:
                 # nonce > confirmed_nonce: out-of-order. Stash for later roll-forward.
                 state.out_of_order_confirmations.add(nonce)
 
-    def on_reorg(self, address: str, reverted_to_nonce: int):
+    def on_reorg(self, address: str, reverted_to_nonce: int, *, chain_id: int = DEFAULT_CHAIN_ID):
         """
         Handles a chain reorganization event for a specific wallet.
         This method should be called by an external chain monitor component
@@ -211,11 +387,16 @@ class NonceManager:
                                `reverted_to_nonce` are considered potentially invalid.
         """
         with self._lock:
-            state = self._get_wallet_state(address)
+            state = self._get_wallet_state(address, chain_id)
+            self._ensure_pending_records(state)
 
             # If the reorg depth implies that our `confirmed_nonce` is no longer valid,
             # revert it to the `reverted_to_nonce` supplied by the reorg detector.
             if state.confirmed_nonce > reverted_to_nonce:
+                for nonce, signature_alg in list(state.confirmed_signature_algs.items()):
+                    if nonce >= reverted_to_nonce:
+                        state.rebroadcast_signature_algs[nonce] = signature_alg
+                        del state.confirmed_signature_algs[nonce]
                 state.confirmed_nonce = reverted_to_nonce
 
             # Drop any stashed out-of-order confirmations the reorg has invalidated.
@@ -236,33 +417,47 @@ class NonceManager:
 
             # Remove identified invalid nonces and their associated transactions from our local state.
             for nonce in nonces_to_remove:
-                state.pending_nonces.remove(nonce)
-                del state.pending_transactions[nonce]
+                record = self._drop_pending_nonce(state, nonce)
+                if record is not None:
+                    state.rebroadcast_signature_algs[nonce] = record.signature_alg
 
             # If a `re_queue_callback` was provided, invoke it for all identified reverted transactions.
             if self._re_queue_callback and reverted_txns:
                 for tx in reverted_txns:
                     self._re_queue_callback(tx)
 
-    def get_pending_nonces(self, address: str) -> SortedSet[int]:
+    def get_pending_nonces(self, address: str, *, chain_id: int = DEFAULT_CHAIN_ID) -> SortedSet[int]:
         """
         Returns a copy of the set of nonces currently marked as pending for an address.
         """
         with self._lock:
-            return SortedSet(self._get_wallet_state(address).pending_nonces)
+            return SortedSet(self._get_wallet_state(address, chain_id).pending_nonces)
 
-    def get_confirmed_nonce(self, address: str) -> int:
+    def get_pending_nonce_records(
+        self,
+        address: str,
+        *,
+        chain_id: int = DEFAULT_CHAIN_ID,
+    ) -> Dict[int, NonceRecord]:
+        """
+        Returns pending nonce records keyed by nonce.
+        """
+        with self._lock:
+            state = self._get_wallet_state(address, chain_id)
+            self._ensure_pending_records(state)
+            return dict(state.pending_records)
+
+    def get_confirmed_nonce(self, address: str, *, chain_id: int = DEFAULT_CHAIN_ID) -> int:
         """
         Returns the highest sequentially confirmed nonce for an address known to the manager.
         """
         with self._lock:
-            return self._get_wallet_state(address).confirmed_nonce
+            return self._get_wallet_state(address, chain_id).confirmed_nonce
 
-    def get_total_pending_transactions(self, address: str) -> int:
+    def get_total_pending_transactions(self, address: str, *, chain_id: int = DEFAULT_CHAIN_ID) -> int:
         """
         Returns the count of transactions currently pending (acquired but not confirmed)
         for a specific address.
         """
         with self._lock:
-            return len(self._get_wallet_state(address).pending_transactions)
-
+            return len(self._get_wallet_state(address, chain_id).pending_transactions)

--- a/tests/test_nonce_manager.py
+++ b/tests/test_nonce_manager.py
@@ -4,7 +4,15 @@ from typing import Dict, Any, List, Callable
 from sortedcontainers import SortedSet
 
 # Assuming nonce_manager.py is correctly importable from 'switchboard' package
-from switchboard.nonce_manager import NonceManager, ChainClient
+from switchboard.nonce_manager import (
+    HybridSignatureAlgorithmReserved,
+    NonceManager,
+    ChainClient,
+    SIGNATURE_ALG_ECDSA,
+    SIGNATURE_ALG_HYBRID,
+    SIGNATURE_ALG_ML_DSA_65,
+    SignatureAlgorithmMismatch,
+)
 
 # --- Mock ChainClient for testing ---
 class MockChainClientImpl:
@@ -365,6 +373,170 @@ class TestNonceManager(unittest.TestCase):
         self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet()) # Pending 1 removed
         self.assertEqual(len(self.re_queued_txns), 1)
         self.assertEqual(self.re_queued_txns[0].nonce, 1)
+
+    def test_next_nonce_records_signature_alg_for_every_pending_record(self):
+        chain_id = 10
+
+        ecdsa_tx = MockTransaction(0, "ecdsa")
+        pq_tx = MockTransaction(1, "ml_dsa_65")
+        self.assertEqual(
+            self.nonce_manager.next_nonce(
+                chain_id,
+                self.wallet_address_1,
+                SIGNATURE_ALG_ECDSA,
+                ecdsa_tx,
+            ),
+            0,
+        )
+        self.assertEqual(
+            self.nonce_manager.next_nonce(
+                chain_id,
+                self.wallet_address_1,
+                SIGNATURE_ALG_ML_DSA_65,
+                pq_tx,
+            ),
+            1,
+        )
+
+        records = self.nonce_manager.get_pending_nonce_records(
+            self.wallet_address_1,
+            chain_id=chain_id,
+        )
+        self.assertEqual(records[0].signature_alg, SIGNATURE_ALG_ECDSA)
+        self.assertEqual(records[0].transaction, ecdsa_tx)
+        self.assertEqual(records[1].signature_alg, SIGNATURE_ALG_ML_DSA_65)
+        self.assertEqual(records[1].transaction, pq_tx)
+
+    def test_existing_pending_records_are_auto_tagged_as_ecdsa(self):
+        state = self.nonce_manager._get_wallet_state(self.wallet_address_1)
+        legacy_tx = MockTransaction(7, "legacy")
+        state.pending_nonces.add(7)
+        state.pending_transactions[7] = legacy_tx
+
+        records = self.nonce_manager.get_pending_nonce_records(self.wallet_address_1)
+        self.assertEqual(records[7].signature_alg, SIGNATURE_ALG_ECDSA)
+        self.assertEqual(records[7].transaction, legacy_tx)
+
+    def test_reorg_blocks_different_alg_rebroadcast_without_override(self):
+        chain_id = 1
+        pq_tx = MockTransaction(0, "pq_signed")
+
+        self.assertEqual(
+            self.nonce_manager.next_nonce(
+                chain_id,
+                self.wallet_address_1,
+                SIGNATURE_ALG_ML_DSA_65,
+                pq_tx,
+            ),
+            0,
+        )
+        self.nonce_manager.confirm_nonce(self.wallet_address_1, 0, chain_id=chain_id)
+        self.nonce_manager.on_reorg(self.wallet_address_1, 0, chain_id=chain_id)
+
+        with self.assertRaises(SignatureAlgorithmMismatch):
+            self.nonce_manager.next_nonce(
+                chain_id,
+                self.wallet_address_1,
+                SIGNATURE_ALG_ECDSA,
+                MockTransaction(0, "ecdsa_replacement"),
+            )
+
+        self.assertEqual(
+            self.nonce_manager.next_nonce(
+                chain_id,
+                self.wallet_address_1,
+                SIGNATURE_ALG_ML_DSA_65,
+                MockTransaction(0, "pq_rebroadcast"),
+            ),
+            0,
+        )
+
+    def test_force_rebroadcast_alg_allows_explicit_alg_change_after_reorg(self):
+        chain_id = 2
+
+        self.assertEqual(
+            self.nonce_manager.next_nonce(
+                chain_id,
+                self.wallet_address_1,
+                SIGNATURE_ALG_ML_DSA_65,
+                MockTransaction(0, "pq_signed"),
+            ),
+            0,
+        )
+        self.nonce_manager.on_reorg(self.wallet_address_1, 0, chain_id=chain_id)
+
+        self.assertEqual(
+            self.nonce_manager.next_nonce(
+                chain_id,
+                self.wallet_address_1,
+                SIGNATURE_ALG_ECDSA,
+                MockTransaction(0, "operator_forced_ecdsa"),
+                force_rebroadcast_alg=True,
+            ),
+            0,
+        )
+        records = self.nonce_manager.get_pending_nonce_records(
+            self.wallet_address_1,
+            chain_id=chain_id,
+        )
+        self.assertEqual(records[0].signature_alg, SIGNATURE_ALG_ECDSA)
+
+    def test_hybrid_signature_alg_is_reserved_behind_feature_flag(self):
+        with self.assertRaises(HybridSignatureAlgorithmReserved):
+            self.nonce_manager.next_nonce(
+                3,
+                self.wallet_address_1,
+                SIGNATURE_ALG_HYBRID,
+            )
+
+        hybrid_manager = NonceManager(self.mock_chain_client, allow_hybrid=True)
+        self.assertEqual(
+            hybrid_manager.next_nonce(
+                3,
+                self.wallet_address_1,
+                SIGNATURE_ALG_HYBRID,
+                MockTransaction(0, "hybrid_reserved"),
+            ),
+            0,
+        )
+        records = hybrid_manager.get_pending_nonce_records(self.wallet_address_1, chain_id=3)
+        self.assertEqual(records[0].signature_alg, SIGNATURE_ALG_HYBRID)
+
+    def test_signature_alg_cross_product_rebroadcast_mismatches(self):
+        algs = [
+            SIGNATURE_ALG_ECDSA,
+            SIGNATURE_ALG_ML_DSA_65,
+            SIGNATURE_ALG_HYBRID,
+        ]
+
+        for original_alg in algs:
+            for replacement_alg in algs:
+                if original_alg == replacement_alg:
+                    continue
+
+                with self.subTest(original_alg=original_alg, replacement_alg=replacement_alg):
+                    manager = NonceManager(self.mock_chain_client, allow_hybrid=True)
+                    address = f"{self.wallet_address_1}_{original_alg}_{replacement_alg}"
+                    chain_id = 99
+
+                    self.assertEqual(
+                        manager.next_nonce(
+                            chain_id,
+                            address,
+                            original_alg,
+                            MockTransaction(0, "original"),
+                        ),
+                        0,
+                    )
+                    manager.on_reorg(address, 0, chain_id=chain_id)
+
+                    with self.assertRaises(SignatureAlgorithmMismatch):
+                        manager.next_nonce(
+                            chain_id,
+                            address,
+                            replacement_alg,
+                            MockTransaction(0, "replacement"),
+                        )
 
     def test_concurrent_access(self):
         """


### PR DESCRIPTION
Refs #79

Summary:
- add signature_alg-tagged NonceRecord state for pending nonces, defaulting legacy in-memory records to ECDSA
- add NonceManager.next_nonce(chain_id, address, alg) with reorg/stale-rebroadcast mismatch protection
- support explicit operator override through force_rebroadcast_alg
- reserve the hybrid signature tag behind allow_hybrid and cover all 3 tags plus 6 cross-product mismatch cases

Validation:
- python -m pytest tests\test_nonce_manager.py -q
- python -m pytest tests\test_nonce_manager.py tests\test_zap_transport.py tests\test_x402_middleware.py -q
- python -m py_compile switchboard\nonce_manager.py tests\test_nonce_manager.py
- git diff --check