### PR TITLE
feat: unify gas_budget.py and gas_tracker.py into GasManager (closes #97)

### DIFF
--- a/docs/gas_manager_design.md
+++ b/docs/gas_manager_design.md
@@ -1,0 +1,58 @@
+# GasManager Unified Design Document
+
+## Problem
+
+Two overlapping gas-management modules exist:
+- `gas_budget.py` — rolling-window, per-wallet, multi-wallet
+- `gas_tracker.py` — calendar-reset, global singleton
+
+They have different semantics and APIs, causing confusion and code duplication.
+
+## Solution: Unified GasManager
+
+A single `GasManager` class that supports both use cases through configuration.
+
+### Key Design Decisions
+
+1. **Window Mode**: `rolling` (deque-based, from gas_budget) or `calendar` (hour-aligned, from gas_tracker)
+2. **Scope**: Per-wallet tracking (default) or global singleton mode
+3. **Backward Compatibility**: Wrappers that reimplement old APIs on top of GasManager
+
+### API Design
+
+```python
+class GasManager:
+    def __init__(
+        self,
+        hourly_limit: int = 0,      # 0 = no limit
+        daily_limit: int = 0,       # 0 = no limit
+        window_mode: str = "rolling",  # "rolling" or "calendar"
+        singleton: bool = False,     # If True, acts as global singleton
+        clock: Callable = time.time,
+    )
+
+    # Core operations
+    def can_spend(self, wallet: str, estimated_gas: int) -> bool
+    def record(self, wallet: str, gas_used: int) -> GasStatus
+    def status(self, wallet: str) -> GasStatus
+
+    # Control
+    def pause(self, wallet: str) -> None
+    def resume(self, wallet: str) -> None
+    def reset(self, wallet: str) -> None
+    def set_limits(self, wallet: str, hourly: int, daily: int) -> None
+
+    # Global mode convenience (uses "global" wallet)
+    def can_send_transaction(self, estimated_gas: int) -> bool
+    def record_gas_usage(self, gas_used: int) -> None
+    def is_paused(self) -> bool
+    def get_current_spent(self) -> tuple[int, int]
+    def reset_all(self) -> None
+```
+
+### Backward Compatibility
+
+- `GasBudgetTracker` → thin wrapper around `GasManager(window_mode="rolling")`
+- `GasTracker` → thin wrapper around `GasManager(window_mode="calendar", singleton=True)`
+
+All existing imports continue to work unchanged.

--- a/switchboard/gas_budget.py
+++ b/switchboard/gas_budget.py
@@ -1,31 +1,10 @@
 """
 Gas budget tracker for agent wallets.
 
-Tracks cumulative gas spent per wallet over rolling hour and day windows,
-enforces configurable limits, and pauses execution when a budget is exhausted.
+Backward-compatible wrapper around GasManager (rolling-window mode).
+Preserves the original API for existing imports.
 
-Implements issue #5:
-    https://github.com/kcolbchain/switchboard/issues/5
-
-Design goals
-------------
-- Monotonic, thread-safe accounting — safe from multiple agent worker threads.
-- Rolling-window enforcement (not calendar buckets), so a burst at 23:59 does
-  not reset to zero one minute later.
-- Pluggable clock for deterministic tests.
-- Pure Python, zero new runtime deps.
-
-Typical usage::
-
-    tracker = GasBudgetTracker(
-        default_limits=GasLimits(per_hour=2_000_000, per_day=20_000_000),
-    )
-
-    if not tracker.can_spend(wallet, estimated_gas):
-        raise BudgetExhausted(tracker.status(wallet))
-
-    # ... send tx ...
-    tracker.record(wallet, gas_used=receipt.gasUsed)
+See switchboard/gas_manager.py for the unified implementation.
 """
 
 from __future__ import annotations
@@ -36,13 +15,20 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Callable, Deque, Dict, Optional
 
+from switchboard.gas_manager import (
+    BudgetExhausted,
+    GasLimits as _GasLimits,
+    GasManager,
+    GasStatus,
+    SECONDS_PER_DAY,
+    SECONDS_PER_HOUR,
+)
 
-SECONDS_PER_HOUR = 3_600
-SECONDS_PER_DAY = 86_400
 
-
-class BudgetExhausted(RuntimeError):
-    """Raised when a wallet would exceed its configured gas budget."""
+# Re-export for backward compatibility
+BudgetExhausted = BudgetExhausted
+SECONDS_PER_HOUR = SECONDS_PER_HOUR
+SECONDS_PER_DAY = SECONDS_PER_DAY
 
 
 @dataclass(frozen=True)
@@ -76,28 +62,10 @@ class BudgetStatus:
         return max(0, self.limits.per_day - self.spent_last_day)
 
 
-@dataclass
-class _WalletLedger:
-    """Internal per-wallet state. Protected by the tracker lock."""
-
-    # (timestamp_seconds, gas_used) entries, oldest first.
-    events: Deque = field(default_factory=deque)
-    sum_hour: int = 0
-    sum_day: int = 0
-    paused: bool = False
-
-
 class GasBudgetTracker:
     """Tracks cumulative gas per wallet and enforces rolling-window limits.
 
-    Parameters
-    ----------
-    default_limits:
-        Applied to any wallet that does not have explicit limits set via
-        :meth:`set_limits`.
-    clock:
-        Injectable seconds-resolution clock. Defaults to :func:`time.time`.
-        Tests should pass a controllable clock to avoid real sleeps.
+    This is a backward-compatible wrapper around GasManager.
     """
 
     def __init__(
@@ -105,129 +73,53 @@ class GasBudgetTracker:
         default_limits: GasLimits = GasLimits(),
         clock: Callable[[], float] = time.time,
     ):
+        self._manager = GasManager(
+            hourly_limit=default_limits.per_hour or 0,
+            daily_limit=default_limits.per_day or 0,
+            window_mode="rolling",
+            clock=clock,
+        )
         self._default_limits = default_limits
-        self._clock = clock
-        self._lock = threading.Lock()
-        self._ledgers: Dict[str, _WalletLedger] = defaultdict(_WalletLedger)
-        self._limits: Dict[str, GasLimits] = {}
-
-    # ---- configuration -------------------------------------------------
 
     def set_limits(self, wallet: str, limits: GasLimits) -> None:
-        """Override the default limits for ``wallet``."""
-        with self._lock:
-            self._limits[wallet] = limits
+        self._manager.set_limits(
+            wallet,
+            hourly=limits.per_hour or 0,
+            daily=limits.per_day or 0,
+        )
 
     def limits_for(self, wallet: str) -> GasLimits:
-        return self._limits.get(wallet, self._default_limits)
-
-    # ---- enforcement ---------------------------------------------------
+        mlim = self._manager.limits_for(wallet)
+        return GasLimits(per_hour=mlim.hourly or None, per_day=mlim.daily or None)
 
     def can_spend(self, wallet: str, estimated_gas: int) -> bool:
-        """Return ``True`` if ``estimated_gas`` fits within every active window."""
-        if estimated_gas < 0:
-            raise ValueError("estimated_gas must be non-negative")
-
-        with self._lock:
-            ledger = self._ledgers[wallet]
-            self._evict_locked(ledger)
-            limits = self.limits_for(wallet)
-
-            if ledger.paused:
-                return False
-            if limits.per_hour is not None and ledger.sum_hour + estimated_gas > limits.per_hour:
-                return False
-            if limits.per_day is not None and ledger.sum_day + estimated_gas > limits.per_day:
-                return False
-            return True
+        return self._manager.can_spend(wallet, estimated_gas)
 
     def check(self, wallet: str, estimated_gas: int) -> None:
-        """Raise :class:`BudgetExhausted` if ``estimated_gas`` cannot be spent."""
-        if not self.can_spend(wallet, estimated_gas):
-            raise BudgetExhausted(self.status(wallet))
+        self._manager.check(wallet, estimated_gas)
 
     def record(self, wallet: str, gas_used: int) -> BudgetStatus:
-        """Record a post-confirmation gas spend and return the new status.
-
-        Auto-pauses the wallet if a limit is crossed after this record.
-        """
-        if gas_used < 0:
-            raise ValueError("gas_used must be non-negative")
-
-        with self._lock:
-            ledger = self._ledgers[wallet]
-            self._evict_locked(ledger)
-
-            now = self._clock()
-            ledger.events.append((now, gas_used))
-            ledger.sum_hour += gas_used
-            ledger.sum_day += gas_used
-
-            limits = self.limits_for(wallet)
-            if (
-                limits.per_hour is not None and ledger.sum_hour >= limits.per_hour
-            ) or (
-                limits.per_day is not None and ledger.sum_day >= limits.per_day
-            ):
-                ledger.paused = True
-
-            return self._status_locked(wallet, ledger, limits)
-
-    # ---- introspection -------------------------------------------------
+        status = self._manager.record(wallet, gas_used)
+        return self._to_budget_status(status)
 
     def status(self, wallet: str) -> BudgetStatus:
-        with self._lock:
-            ledger = self._ledgers[wallet]
-            self._evict_locked(ledger)
-            return self._status_locked(wallet, ledger, self.limits_for(wallet))
+        status = self._manager.status(wallet)
+        return self._to_budget_status(status)
 
     def resume(self, wallet: str) -> None:
-        """Manually unpause a wallet. The operator is responsible for ensuring
-        the underlying budget has freed up — this does not reset counters."""
-        with self._lock:
-            self._ledgers[wallet].paused = False
+        self._manager.resume(wallet)
 
     def reset(self, wallet: str) -> None:
-        """Clear all recorded spend for ``wallet`` (e.g. after a new funding round)."""
-        with self._lock:
-            self._ledgers[wallet] = _WalletLedger()
+        self._manager.reset(wallet)
 
-    # ---- internals -----------------------------------------------------
-
-    def _evict_locked(self, ledger: _WalletLedger) -> None:
-        """Drop events that have aged out of both windows and refresh sums."""
-        now = self._clock()
-        day_cutoff = now - SECONDS_PER_DAY
-        hour_cutoff = now - SECONDS_PER_HOUR
-
-        # Evict from the daily window (which also removes from hourly).
-        while ledger.events and ledger.events[0][0] <= day_cutoff:
-            ts, gas = ledger.events.popleft()
-            ledger.sum_day -= gas
-            if ts > hour_cutoff:
-                # Shouldn't happen — hour window is a subset of day — but keep
-                # sums consistent defensively.
-                ledger.sum_hour -= gas
-
-        # Rebuild sum_hour from events (cheap: bounded by day window size).
-        ledger.sum_hour = sum(gas for ts, gas in ledger.events if ts > hour_cutoff)
-
-        # Auto-unpause if limits have freed up again.
-        if ledger.paused:
-            limits_ok_hour = True
-            limits_ok_day = True
-            # We don't know wallet limits here; caller re-checks before spending.
-            # We keep paused sticky until explicit resume() or a fresh record()
-            # re-evaluates. See docstring on resume().
-            del limits_ok_hour, limits_ok_day
-
-    def _status_locked(
-        self, wallet: str, ledger: _WalletLedger, limits: GasLimits
-    ) -> BudgetStatus:
+    def _to_budget_status(self, s: GasStatus) -> BudgetStatus:
         return BudgetStatus(
-            wallet=wallet,
-            limits=limits,
-            spent_last_hour=ledger.sum_hour,
-            spent_last_day=ledger.sum_day,
-            paused=ledger.paused,
+            wallet=s.wallet,
+            limits=GasLimits(
+                per_hour=s.limits.hourly or None,
+                per_day=s.limits.daily or None,
+            ),
+            spent_last_hour=s.spent_hourly,
+            spent_last_day=s.spent_daily,
+            paused=s.paused,
         )

--- a/switchboard/gas_manager.py
+++ b/switchboard/gas_manager.py
@@ -1,0 +1,379 @@
+"""
+Unified gas management for agent wallets.
+
+Combines the functionality of gas_budget.py (rolling-window, per-wallet)
+and gas_tracker.py (calendar-reset, global singleton) into a single,
+configurable GasManager class.
+
+Design doc: docs/gas_manager_design.md
+"""
+
+from __future__ import annotations
+
+import datetime
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Deque, Dict, Optional, Tuple
+
+
+SECONDS_PER_HOUR = 3_600
+SECONDS_PER_DAY = 86_400
+GLOBAL_WALLET = "__global__"
+
+
+class WindowMode(Enum):
+    ROLLING = "rolling"
+    CALENDAR = "calendar"
+
+
+class BudgetExhausted(RuntimeError):
+    """Raised when a wallet would exceed its configured gas budget."""
+
+    def __init__(self, status: "GasStatus"):
+        self.status = status
+        # args[0] is the status object for backward compatibility
+        # (old tests check exc.value.args[0].wallet)
+        super().__init__(status)
+
+
+@dataclass(frozen=True)
+class GasLimits:
+    """Per-wallet gas ceilings. 0 or None disables the corresponding window."""
+
+    hourly: int = 0
+    daily: int = 0
+
+
+@dataclass
+class GasStatus:
+    """Snapshot of a wallet's current spend vs. its limits."""
+
+    wallet: str
+    limits: GasLimits
+    spent_hourly: int
+    spent_daily: int
+    paused: bool
+    window_mode: WindowMode
+
+    @property
+    def remaining_hourly(self) -> int:
+        if self.limits.hourly <= 0:
+            return -1  # unlimited
+        return max(0, self.limits.hourly - self.spent_hourly)
+
+    @property
+    def remaining_daily(self) -> int:
+        if self.limits.daily <= 0:
+            return -1  # unlimited
+        return max(0, self.limits.daily - self.spent_daily)
+
+
+@dataclass
+class _WalletState:
+    """Internal per-wallet state. Protected by the manager lock."""
+
+    # Rolling mode: (timestamp, gas_used) entries
+    events: Deque = field(default_factory=deque)
+    # Calendar mode: simple counters
+    spent_hourly: int = 0
+    spent_daily: int = 0
+    last_reset_hour: float = 0.0
+    last_reset_day: float = 0.0
+    # Common
+    paused: bool = False
+    limits: Optional[GasLimits] = None
+
+
+class GasManager:
+    """Unified gas manager supporting rolling-window and calendar modes.
+
+    Parameters
+    ----------
+    hourly_limit:
+        Default hourly gas limit. 0 means no limit.
+    daily_limit:
+        Default daily gas limit. 0 means no limit.
+    window_mode:
+        "rolling" for deque-based sliding window (from gas_budget.py),
+        "calendar" for hour-aligned resets (from gas_tracker.py).
+    singleton:
+        If True, behaves as a global singleton (like GasTracker).
+    clock:
+        Injectable seconds-resolution clock. Defaults to time.time.
+    """
+
+    _singleton_instance: Optional["GasManager"] = None
+    _singleton_lock = threading.Lock()
+
+    def __new__(cls, *args, **kwargs):
+        """Support singleton mode when requested."""
+        if kwargs.get("singleton", False):
+            if cls._singleton_instance is None:
+                with cls._singleton_lock:
+                    if cls._singleton_instance is None:
+                        instance = super().__new__(cls)
+                        instance._is_singleton = True
+                        cls._singleton_instance = instance
+            return cls._singleton_instance
+        return super().__new__(cls)
+
+    def __init__(
+        self,
+        hourly_limit: int = 0,
+        daily_limit: int = 0,
+        window_mode: str = "rolling",
+        singleton: bool = False,
+        clock: Callable[[], float] = time.time,
+    ):
+        if hasattr(self, "_initialized"):
+            return
+
+        self._default_limits = GasLimits(hourly=hourly_limit, daily=daily_limit)
+        self._window_mode = WindowMode(window_mode)
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._wallets: Dict[str, _WalletState] = defaultdict(_WalletState)
+        self._initialized = True
+
+        # Calendar mode: align initial day to UTC midnight
+        if self._window_mode == WindowMode.CALENDAR:
+            now = self._clock()
+            for state in self._wallets.values():
+                state.last_reset_hour = now
+                state.last_reset_day = self._align_to_day_start(now)
+
+    # ---- Configuration ---------------------------------------------------
+
+    def set_limits(self, wallet: str, hourly: int = 0, daily: int = 0) -> None:
+        """Set per-wallet limits, overriding defaults."""
+        with self._lock:
+            state = self._wallets[wallet]
+            state.limits = GasLimits(hourly=hourly, daily=daily)
+            if self._window_mode == WindowMode.CALENDAR:
+                self._maybe_reset_calendar(state)
+            self._update_pause_state(state, state.limits or self._default_limits)
+
+    def limits_for(self, wallet: str) -> GasLimits:
+        """Return effective limits for a wallet."""
+        with self._lock:
+            state = self._wallets[wallet]
+            return state.limits if state.limits is not None else self._default_limits
+
+    # ---- Core Operations -------------------------------------------------
+
+    def can_spend(self, wallet: str, estimated_gas: int) -> bool:
+        """Return True if estimated_gas fits within all active windows."""
+        if estimated_gas < 0:
+            raise ValueError("estimated_gas must be non-negative")
+
+        with self._lock:
+            state = self._wallets[wallet]
+            limits = state.limits if state.limits is not None else self._default_limits
+
+            if self._window_mode == WindowMode.ROLLING:
+                self._evict_rolling(state)
+            else:
+                self._maybe_reset_calendar(state)
+
+            if state.paused:
+                return False
+
+            if limits.hourly > 0:
+                spent = self._get_hourly_spent(state)
+                if spent + estimated_gas > limits.hourly:
+                    return False
+
+            if limits.daily > 0:
+                spent = self._get_daily_spent(state)
+                if spent + estimated_gas > limits.daily:
+                    return False
+
+            return True
+
+    def check(self, wallet: str, estimated_gas: int) -> None:
+        """Raise BudgetExhausted if estimated_gas cannot be spent."""
+        if not self.can_spend(wallet, estimated_gas):
+            raise BudgetExhausted(self.status(wallet))
+
+    def record(self, wallet: str, gas_used: int) -> GasStatus:
+        """Record gas spend and return new status. Auto-pauses if limit crossed."""
+        if gas_used < 0:
+            raise ValueError("gas_used must be non-negative")
+
+        with self._lock:
+            state = self._wallets[wallet]
+            limits = state.limits if state.limits is not None else self._default_limits
+
+            if self._window_mode == WindowMode.ROLLING:
+                self._evict_rolling(state)
+                now = self._clock()
+                state.events.append((now, gas_used))
+            else:
+                self._maybe_reset_calendar(state)
+                state.spent_hourly += gas_used
+                state.spent_daily += gas_used
+
+            # Check if we should pause
+            if limits.hourly > 0 and self._get_hourly_spent(state) >= limits.hourly:
+                state.paused = True
+            if limits.daily > 0 and self._get_daily_spent(state) >= limits.daily:
+                state.paused = True
+
+            return self._make_status(wallet, state, limits)
+
+    # ---- Introspection ---------------------------------------------------
+
+    def status(self, wallet: str) -> GasStatus:
+        """Return current status for a wallet."""
+        with self._lock:
+            state = self._wallets[wallet]
+            limits = state.limits if state.limits is not None else self._default_limits
+
+            if self._window_mode == WindowMode.ROLLING:
+                self._evict_rolling(state)
+            else:
+                self._maybe_reset_calendar(state)
+
+            return self._make_status(wallet, state, limits)
+
+    # ---- Control ---------------------------------------------------------
+
+    def pause(self, wallet: str) -> None:
+        """Manually pause a wallet."""
+        with self._lock:
+            self._wallets[wallet].paused = True
+
+    def resume(self, wallet: str) -> None:
+        """Manually unpause a wallet."""
+        with self._lock:
+            self._wallets[wallet].paused = False
+
+    def reset(self, wallet: str) -> None:
+        """Clear all recorded spend for a wallet."""
+        with self._lock:
+            self._wallets[wallet] = _WalletState()
+            if self._window_mode == WindowMode.CALENDAR:
+                now = self._clock()
+                self._wallets[wallet].last_reset_hour = now
+                self._wallets[wallet].last_reset_day = self._align_to_day_start(now)
+
+    # ---- Global/singleton convenience methods ----------------------------
+
+    def can_send_transaction(self, estimated_gas_cost: int) -> bool:
+        """Global mode: check if transaction fits (uses GLOBAL_WALLET)."""
+        return self.can_spend(GLOBAL_WALLET, estimated_gas_cost)
+
+    def record_gas_usage(self, gas_used: int) -> None:
+        """Global mode: record gas usage (uses GLOBAL_WALLET)."""
+        self.record(GLOBAL_WALLET, gas_used)
+
+    def is_paused(self) -> bool:
+        """Global mode: check if paused (uses GLOBAL_WALLET)."""
+        return self.status(GLOBAL_WALLET).paused
+
+    def get_current_spent(self) -> Tuple[int, int]:
+        """Global mode: return (hourly_spent, daily_spent)."""
+        s = self.status(GLOBAL_WALLET)
+        return (s.spent_hourly, s.spent_daily)
+
+    def reset_all(self) -> None:
+        """Global mode: reset all state."""
+        with self._lock:
+            self._wallets.clear()
+            if self._window_mode == WindowMode.CALENDAR:
+                now = self._clock()
+                state = self._wallets[GLOBAL_WALLET]
+                state.last_reset_hour = now
+                state.last_reset_day = self._align_to_day_start(now)
+
+    # ---- Internals -------------------------------------------------------
+
+    def _get_hourly_spent(self, state: _WalletState) -> int:
+        """Get hourly spent based on window mode."""
+        if self._window_mode == WindowMode.ROLLING:
+            cutoff = self._clock() - SECONDS_PER_HOUR
+            return sum(gas for ts, gas in state.events if ts > cutoff)
+        return state.spent_hourly
+
+    def _get_daily_spent(self, state: _WalletState) -> int:
+        """Get daily spent based on window mode."""
+        if self._window_mode == WindowMode.ROLLING:
+            cutoff = self._clock() - SECONDS_PER_DAY
+            return sum(gas for ts, gas in state.events if ts > cutoff)
+        return state.spent_daily
+
+    def _evict_rolling(self, state: _WalletState) -> None:
+        """Drop events that have aged out of the daily window."""
+        cutoff = self._clock() - SECONDS_PER_DAY
+        while state.events and state.events[0][0] <= cutoff:
+            state.events.popleft()
+
+    def _maybe_reset_calendar(self, state: _WalletState) -> None:
+        """Reset hourly/daily counters if calendar boundaries crossed."""
+        now = self._clock()
+
+        # Hourly reset
+        if now - state.last_reset_hour >= SECONDS_PER_HOUR:
+            state.spent_hourly = 0
+            state.last_reset_hour = now - (now % SECONDS_PER_HOUR)
+
+        # Daily reset
+        current_day = self._timestamp_to_day(now)
+        last_day = self._timestamp_to_day(state.last_reset_day)
+        if current_day > last_day:
+            state.spent_daily = 0
+            state.last_reset_day = self._align_to_day_start(now)
+
+        # Auto-unpause if limits are now satisfied
+        limits = state.limits if state.limits is not None else self._default_limits
+        self._update_pause_state(state, limits)
+
+    def _update_pause_state(self, state: _WalletState, limits: GasLimits) -> None:
+        """Update pause flag based on current spending and limits.
+
+        Pauses if any limit is exceeded. In calendar mode, also unpauses when
+        limits are satisfied (auto-reset). In rolling mode, stays paused until
+        explicit resume() — this matches the original GasBudgetTracker behavior.
+        """
+        over_hourly = limits.hourly > 0 and self._get_hourly_spent(state) >= limits.hourly
+        over_daily = limits.daily > 0 and self._get_daily_spent(state) >= limits.daily
+
+        if over_hourly or over_daily:
+            state.paused = True
+        elif self._window_mode == WindowMode.CALENDAR:
+            # Calendar mode: auto-unpause when limits are satisfied
+            state.paused = False
+        # Rolling mode: don't auto-unpause (stay sticky until resume())
+
+    def _make_status(self, wallet: str, state: _WalletState, limits: GasLimits) -> GasStatus:
+        return GasStatus(
+            wallet=wallet,
+            limits=limits,
+            spent_hourly=self._get_hourly_spent(state),
+            spent_daily=self._get_daily_spent(state),
+            paused=state.paused,
+            window_mode=self._window_mode,
+        )
+
+    @staticmethod
+    def _align_to_day_start(timestamp: float) -> float:
+        """Align timestamp to start of UTC day."""
+        dt = datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+        start = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        return start.timestamp()
+
+    @staticmethod
+    def _timestamp_to_day(timestamp: float) -> datetime.date:
+        """Convert timestamp to UTC date."""
+        return datetime.datetime.fromtimestamp(
+            timestamp, tz=datetime.timezone.utc
+        ).date()
+
+    @classmethod
+    def reset_singleton(cls) -> None:
+        """Reset the singleton instance (for testing)."""
+        with cls._singleton_lock:
+            cls._singleton_instance = None

--- a/switchboard/gas_tracker.py
+++ b/switchboard/gas_tracker.py
@@ -1,197 +1,85 @@
+"""
+Gas tracker for agent wallets.
+
+Backward-compatible wrapper around GasManager (calendar-reset, singleton mode).
+Preserves the original API for existing imports.
+
+See switchboard/gas_manager.py for the unified implementation.
+"""
+
+from __future__ import annotations
+
 import time
 import threading
-from typing import Optional, Callable
-import datetime
+from typing import Optional, Callable, Tuple
+
+from switchboard.gas_manager import (
+    GasManager,
+    GLOBAL_WALLET,
+)
+
 
 class GasBudgetExhaustedError(Exception):
-    """
-    Custom exception raised for informational purposes when gas budget is exhausted.
-    The `GasTracker` itself will pause subsequent `can_send_transaction` calls,
-    but it's up to the caller to handle this immediate exhaustion event.
-    """
+    """Raised when gas budget is exhausted."""
     pass
+
 
 class GasTracker:
     """
     Tracks cumulative gas spent and enforces configurable hourly and daily limits.
-    If a limit is exceeded, the tracker's `is_paused()` method will return True,
-    and `can_send_transaction()` will return False until the budget resets.
-    This class is implemented as a singleton to ensure a single, consistent
-    gas budget is managed across the application.
+    Backward-compatible wrapper around GasManager (calendar mode, singleton).
     """
-    _instance: Optional['GasTracker'] = None
-    _lock = threading.Lock() # For singleton instantiation
+
+    _instance: Optional["GasTracker"] = None
+    _lock = threading.Lock()
 
     def __new__(cls, *args, **kwargs):
-        """
-        Ensures that only one instance of GasTracker is created (singleton pattern).
-        """
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self, hourly_limit: int = 0, daily_limit: int = 0, time_source: Callable[[], float] = time.time):
-        """
-        Initializes the GasTracker.
-        
-        Args:
-            hourly_limit (int): Maximum gas allowed per hour. 0 means no hourly limit.
-            daily_limit (int): Maximum gas allowed per day. 0 means no daily limit.
-            time_source (Callable[[], float]): A function that returns the current time
-                                              as a float timestamp. Defaults to `time.time`.
-        """
-        if not hasattr(self, '_initialized'):
+    def __init__(
+        self,
+        hourly_limit: int = 0,
+        daily_limit: int = 0,
+        time_source: Callable[[], float] = time.time,
+    ):
+        if not hasattr(self, "_initialized"):
+            self._manager = GasManager(
+                hourly_limit=hourly_limit,
+                daily_limit=daily_limit,
+                window_mode="calendar",
+                clock=time_source,
+            )
             self._hourly_limit = hourly_limit
             self._daily_limit = daily_limit
-            self._spent_gas_hourly = 0
-            self._spent_gas_daily = 0
-            self._time_source = time_source # Callable to get current timestamp
-            self._last_reset_hour = self._time_source()
-            self._last_reset_day = self._time_source()
-            self._is_paused = False # True if any limit is currently exceeded
-            self._tracker_lock = threading.Lock() # For internal state changes
+            self._time_source = time_source
             self._initialized = True
-            
-            self._align_last_reset_day() # Ensure daily timestamp is at start of day
-            self._update_pause_state() # Check initial limits based on current spent (if any)
 
-    def _align_last_reset_day(self):
-        """
-        Aligns `_last_reset_day` to the start of the current UTC day.
-        This ensures daily limits reset consistently at midnight UTC.
-        """
-        current_datetime_utc = datetime.datetime.fromtimestamp(self._time_source(), tz=datetime.timezone.utc)
-        start_of_day_utc = current_datetime_utc.replace(hour=0, minute=0, second=0, microsecond=0)
-        self._last_reset_day = start_of_day_utc.timestamp()
-
-    def _update_pause_state(self):
-        """
-        Internal method to update the `_is_paused` flag based on current spending and limits.
-        Sets `_is_paused` to True if any limit is currently exceeded.
-        """
-        can_proceed_hourly = (self._hourly_limit == 0) or (self._spent_gas_hourly < self._hourly_limit)
-        can_proceed_daily = (self._daily_limit == 0) or (self._spent_gas_daily < self._daily_limit)
-        self._is_paused = not (can_proceed_hourly and can_proceed_daily)
-
-    def _reset_if_needed(self):
-        """
-        Checks if an hour or day has passed since the last reset and resets counters.
-        Also updates the pause state. This method should be called before any
-        interaction with the tracker's state (e.g., recording gas, checking limits).
-        """
-        now = self._time_source()
-        
-        # Hourly reset
-        # Aligns _last_reset_hour to the start of the current full hour.
-        if now - self._last_reset_hour >= 3600: # 1 hour
-            self._spent_gas_hourly = 0
-            self._last_reset_hour = now - (now % 3600) # Align to start of current hour
-
-        # Daily reset
-        current_day_dt = datetime.datetime.fromtimestamp(now, tz=datetime.timezone.utc).date()
-        last_reset_day_dt = datetime.datetime.fromtimestamp(self._last_reset_day, tz=datetime.timezone.utc).date()
-        
-        if current_day_dt > last_reset_day_dt:
-            self._spent_gas_daily = 0
-            self._align_last_reset_day()
-
-        self._update_pause_state()
-
-    def record_gas_usage(self, gas_used: int):
-        """
-        Records actual gas used for a confirmed transaction.
-        Updates internal spending totals and the pause state.
-        This method should be called after a transaction has successfully
-        completed and its actual gas usage is known.
-        
-        Args:
-            gas_used (int): The amount of gas used by the transaction.
-        """
-        with self._tracker_lock:
-            self._reset_if_needed() # Always check for resets before recording
-
-            self._spent_gas_hourly += gas_used
-            self._spent_gas_daily += gas_used
-            
-            self._update_pause_state() # Recalculate pause state after adding gas
+    def record_gas_usage(self, gas_used: int) -> None:
+        self._manager.record_gas_usage(gas_used)
 
     def can_send_transaction(self, estimated_gas_cost: int) -> bool:
-        """
-        Checks if a transaction with the given estimated gas cost can be sent
-        without exceeding current limits. This method should be called
-        before attempting to send a transaction.
-        
-        Args:
-            estimated_gas_cost (int): The estimated gas cost for the transaction.
-            
-        Returns:
-            bool: True if the transaction can be sent, False otherwise.
-        """
-        with self._tracker_lock:
-            self._reset_if_needed() # Always check for resets before deciding
-
-            if self._is_paused:
-                return False
-
-            if self._hourly_limit > 0 and (self._spent_gas_hourly + estimated_gas_cost) > self._hourly_limit:
-                return False
-            
-            if self._daily_limit > 0 and (self._spent_gas_daily + estimated_gas_cost) > self._daily_limit:
-                return False
-            
-            return True
+        return self._manager.can_send_transaction(estimated_gas_cost)
 
     def is_paused(self) -> bool:
-        """
-        Returns True if the tracker is currently paused due to budget exhaustion.
-        This flag is updated automatically on resets and when gas is recorded.
-        
-        Returns:
-            bool: True if paused, False otherwise.
-        """
-        with self._tracker_lock:
-            self._reset_if_needed() # Ensure current state is up-to-date
-            return self._is_paused
-            
-    def set_limits(self, hourly_limit: int = 0, daily_limit: int = 0):
-        """
-        Sets new hourly and daily gas limits.
-        Updates the pause state based on new limits and current spending.
-        
-        Args:
-            hourly_limit (int): The new hourly gas limit.
-            daily_limit (int): The new daily gas limit.
-        """
-        with self._tracker_lock:
-            self._hourly_limit = hourly_limit
-            self._daily_limit = daily_limit
-            self._reset_if_needed() # Apply potential resets based on time
-            self._update_pause_state() # Update pause state considering new limits
+        return self._manager.is_paused()
 
-    def get_current_spent(self) -> tuple[int, int]:
-        """
-        Returns current (hourly_spent, daily_spent) gas totals.
-        
-        Returns:
-            tuple[int, int]: A tuple containing current hourly spent gas and daily spent gas.
-        """
-        with self._tracker_lock:
-            self._reset_if_needed()
-            return self._spent_gas_hourly, self._spent_gas_daily
+    def set_limits(self, hourly_limit: int = 0, daily_limit: int = 0) -> None:
+        self._hourly_limit = hourly_limit
+        self._daily_limit = daily_limit
+        self._manager.set_limits(GLOBAL_WALLET, hourly_limit, daily_limit)
 
-    def reset_all(self):
-        """
-        Resets all internal counters to zero, unpauses the tracker,
-        and sets reset timestamps to the current time.
-        Useful for testing or complete reconfiguration.
-        """
-        with self._tracker_lock:
-            self._spent_gas_hourly = 0
-            self._spent_gas_daily = 0
-            self._last_reset_hour = self._time_source()
-            self._align_last_reset_day()
-            self._is_paused = False # Explicitly unpause
-            self._update_pause_state() # Re-evaluate pause state (should be unpaused)
+    def get_current_spent(self) -> Tuple[int, int]:
+        return self._manager.get_current_spent()
 
+    def reset_all(self) -> None:
+        self._manager.reset_all()
+
+    @classmethod
+    def reset_singleton(cls) -> None:
+        """Reset singleton for testing."""
+        cls._instance = None
+        GasManager.reset_singleton()

--- a/tests/test_gas_manager.py
+++ b/tests/test_gas_manager.py
@@ -1,0 +1,210 @@
+"""Tests for the unified GasManager class."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from switchboard.gas_manager import (
+    BudgetExhausted,
+    GasLimits,
+    GasManager,
+    GasStatus,
+    GLOBAL_WALLET,
+    WindowMode,
+    SECONDS_PER_DAY,
+    SECONDS_PER_HOUR,
+)
+
+
+class FakeClock:
+    """Deterministic monotonically-controllable clock."""
+
+    def __init__(self, start: float = 1_700_000_000.0):
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+WALLET = "0xAgent"
+
+
+# ---------------------------------------------------------------- rolling mode
+
+
+class TestRollingMode:
+
+    def test_basic_rolling_workflow(self):
+        clock = FakeClock()
+        mgr = GasManager(hourly_limit=100_000, window_mode="rolling", clock=clock)
+
+        assert mgr.can_spend(WALLET, 60_000)
+        status = mgr.record(WALLET, 60_000)
+        assert status.spent_hourly == 60_000
+        assert status.paused is False
+
+    def test_rolling_window_expires(self):
+        clock = FakeClock()
+        mgr = GasManager(hourly_limit=100_000, window_mode="rolling", clock=clock)
+
+        mgr.record(WALLET, 90_000)
+        assert mgr.can_spend(WALLET, 20_000) is False
+
+        clock.advance(SECONDS_PER_HOUR + 1)
+        # Rolling window expired: 90k aged out, so 20k now fits
+        assert mgr.can_spend(WALLET, 20_000) is True
+
+    def test_rolling_pause_stays_until_resume(self):
+        """Rolling mode: pause is sticky until explicit resume()."""
+        clock = FakeClock()
+        mgr = GasManager(hourly_limit=100_000, window_mode="rolling", clock=clock)
+
+        # Record enough to hit the limit exactly
+        mgr.record(WALLET, 100_000)
+        assert mgr.status(WALLET).paused is True
+        assert mgr.can_spend(WALLET, 1) is False
+
+        # Even after time passes, pause stays (rolling mode is sticky)
+        clock.advance(SECONDS_PER_HOUR + 1)
+        assert mgr.can_spend(WALLET, 1) is False
+
+        # Only explicit resume clears it
+        mgr.resume(WALLET)
+        assert mgr.can_spend(WALLET, 100_000) is True
+
+    def test_rolling_multi_wallet(self):
+        mgr = GasManager(hourly_limit=10_000, window_mode="rolling")
+
+        mgr.record("wallet_a", 8_000)
+        mgr.record("wallet_b", 5_000)
+
+        assert mgr.can_spend("wallet_a", 3_000) is False
+        assert mgr.can_spend("wallet_b", 5_000) is True
+
+
+# ---------------------------------------------------------------- calendar mode
+
+
+class TestCalendarMode:
+
+    def test_basic_calendar_workflow(self):
+        clock = FakeClock()
+        mgr = GasManager(hourly_limit=1_000, daily_limit=5_000, window_mode="calendar", clock=clock)
+
+        assert mgr.can_spend(GLOBAL_WALLET, 500)
+        mgr.record(GLOBAL_WALLET, 500)
+        assert mgr.get_current_spent() == (500, 500)
+
+    def test_calendar_hourly_reset(self):
+        clock = FakeClock()
+        mgr = GasManager(hourly_limit=500, daily_limit=5_000, window_mode="calendar", clock=clock)
+
+        mgr.record(GLOBAL_WALLET, 500)
+        assert mgr.is_paused() is True
+
+        clock.advance(SECONDS_PER_HOUR + 1)
+        # Hour reset should auto-unpause
+        assert mgr.can_send_transaction(100) is True
+        assert mgr.get_current_spent() == (0, 500)
+
+    def test_calendar_daily_reset(self):
+        clock = FakeClock()
+        mgr = GasManager(hourly_limit=10_000, daily_limit=1_000, window_mode="calendar", clock=clock)
+
+        mgr.record(GLOBAL_WALLET, 1_000)
+        assert mgr.is_paused() is True
+
+        clock.advance(SECONDS_PER_DAY + 1)
+        assert mgr.can_send_transaction(100) is True
+        assert mgr.get_current_spent() == (0, 0)
+
+
+# ---------------------------------------------------------------- unified features
+
+
+class TestUnifiedFeatures:
+
+    def test_rolling_mode_has_global_convenience(self):
+        """Rolling mode should also support global convenience methods."""
+        mgr = GasManager(hourly_limit=10_000, window_mode="rolling")
+
+        mgr.record_gas_usage(5_000)
+        assert mgr.get_current_spent() == (5_000, 5_000)
+        assert mgr.is_paused() is False
+
+    def test_calendar_mode_has_per_wallet(self):
+        """Calendar mode should support per-wallet tracking."""
+        clock = FakeClock()
+        mgr = GasManager(hourly_limit=1_000, window_mode="calendar", clock=clock)
+
+        mgr.set_limits("vip", hourly=5_000)
+        mgr.record("vip", 3_000)
+        mgr.record("regular", 900)
+
+        assert mgr.status("vip").paused is False
+        assert mgr.status("regular").paused is False
+        assert mgr.can_spend("regular", 200) is False
+
+    def test_pause_resume(self):
+        mgr = GasManager(window_mode="rolling")
+
+        mgr.pause(WALLET)
+        assert mgr.can_spend(WALLET, 1) is False
+
+        mgr.resume(WALLET)
+        assert mgr.can_spend(WALLET, 1) is True
+
+    def test_reset_clears_state(self):
+        mgr = GasManager(hourly_limit=100, window_mode="rolling")
+
+        mgr.record(WALLET, 100)
+        assert mgr.status(WALLET).paused is True
+
+        mgr.reset(WALLET)
+        assert mgr.status(WALLET).paused is False
+        assert mgr.status(WALLET).spent_hourly == 0
+
+    def test_check_raises_with_status(self):
+        mgr = GasManager(hourly_limit=100, window_mode="rolling")
+
+        mgr.record(WALLET, 100)
+        with pytest.raises(BudgetExhausted) as exc:
+            mgr.check(WALLET, 1)
+        assert exc.value.status.wallet == WALLET
+        assert exc.value.args[0].wallet == WALLET
+
+    def test_thread_safety(self):
+        mgr = GasManager(window_mode="rolling")
+        N = 500
+        workers = 8
+
+        def run():
+            for _ in range(N):
+                mgr.record(WALLET, 1)
+
+        threads = [threading.Thread(target=run) for _ in range(workers)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert mgr.status(WALLET).spent_hourly == N * workers
+
+    def test_negative_values_rejected(self):
+        mgr = GasManager(window_mode="rolling")
+        with pytest.raises(ValueError):
+            mgr.record(WALLET, -1)
+        with pytest.raises(ValueError):
+            mgr.can_spend(WALLET, -1)
+
+    def test_singleton_mode(self):
+        GasManager.reset_singleton()
+        m1 = GasManager(hourly_limit=100, singleton=True)
+        m2 = GasManager(hourly_limit=200, singleton=True)
+        assert m1 is m2
+        GasManager.reset_singleton()


### PR DESCRIPTION
Closes #97

## Summary
Unifies `gas_budget.py` (rolling-window, per-wallet) and `gas_tracker.py` (calendar-reset, singleton) into a single `GasManager` class.

## Changes
- **New:** `switchboard/gas_manager.py` — unified `GasManager` supporting both modes
- **Updated:** `switchboard/gas_budget.py` — backward-compatible wrapper
- **Updated:** `switchboard/gas_tracker.py` — backward-compatible wrapper
- **New:** `tests/test_gas_manager.py` — 15 new tests for unified behavior
- **New:** `docs/gas_manager_design.md` — design document

## Acceptance Criteria
- [x] Design doc (1 page max)
- [x] `GasManager` supports rolling-window AND calendar modes, per-wallet AND global
- [x] Backward-compatible wrappers (all existing imports work)
- [x] All 26 existing tests pass unchanged
- [x] 15 new tests for unified behavior (41 total)
- [x] All tests pass with `pytest`