### PR TITLE
test: cover multi-page lab production links

### DIFF
--- a/tests/test_web_lab.py
+++ b/tests/test_web_lab.py
@@ -1,6 +1,6 @@
-"""Smoke tests for the agent-payments lab (``web/agents-demo.html``).
+"""Smoke tests for the agent-payments canvas lab (``web/agents-demo.html``).
 
-The lab is intentionally a no-build single-file frontend, so the test
+The canvas lab is intentionally a no-build single-file frontend, so the test
 surface here is correspondingly small but load-bearing:
 
 - the file parses as HTML and contains the structural anchors we depend on
@@ -8,7 +8,7 @@ surface here is correspondingly small but load-bearing:
   definition with a name + caption
 - the named cast (Patty, Abhi, Tridib) is wired through the canonical
   agent registry
-- the home page links to the lab and the lab links back
+- the home page links to the multi-page lab and canvas lab
 - the embedded JavaScript has no syntax errors (run via ``node --check``)
 
 Skip the node check if a ``node`` binary isn't on PATH.
@@ -29,7 +29,25 @@ import pytest
 HERE = Path(__file__).resolve().parent
 WEB = HERE.parent / "web"
 LAB = WEB / "agents-demo.html"
+MULTIPAGE_LAB = WEB / "lab"
 HOME = WEB / "index.html"
+SIMULATOR = WEB / "simulator.html"
+
+LAB_PAGES = [
+    "index.html",
+    "x402.html",
+    "escrow.html",
+    "streaming.html",
+    "auction.html",
+    "taxi.html",
+    "cafe.html",
+    "delivery.html",
+    "trip.html",
+    "multichain.html",
+    "pq.html",
+    "rails.html",
+    "tools.html",
+]
 
 
 @pytest.fixture(scope="module")
@@ -43,10 +61,26 @@ def home_html() -> str:
 
 
 @pytest.fixture(scope="module")
+def simulator_html() -> str:
+    return SIMULATOR.read_text()
+
+
+@pytest.fixture(scope="module")
 def lab_script(lab_html: str) -> str:
     m = re.search(r"<script>(.*?)</script>", lab_html, re.DOTALL)
     assert m, "expected one <script> block in lab HTML"
     return m.group(1)
+
+
+def runnable_node() -> str | None:
+    node = shutil.which("node")
+    if node is None:
+        return None
+    try:
+        subprocess.run([node, "--version"], capture_output=True, check=False, timeout=5)
+    except OSError:
+        return None
+    return node
 
 
 # ─── shape ────────────────────────────────────────────────────────────────
@@ -54,6 +88,8 @@ def lab_script(lab_html: str) -> str:
 def test_files_exist() -> None:
     assert LAB.is_file(), f"missing {LAB}"
     assert HOME.is_file(), f"missing {HOME}"
+    for page in LAB_PAGES:
+        assert (MULTIPAGE_LAB / page).is_file(), f"missing {MULTIPAGE_LAB / page}"
 
 
 def test_html_parses(lab_html: str) -> None:
@@ -157,7 +193,13 @@ def test_no_stale_old_names_in_captions(lab_script: str) -> None:
 # ─── home page link ───────────────────────────────────────────────────────
 
 def test_home_links_to_lab(home_html: str) -> None:
-    assert 'href="./agents-demo.html"' in home_html, "home page missing lab link"
+    assert 'href="./lab/index.html"' in home_html, "home page missing multi-page lab link"
+    assert 'href="./agents-demo.html"' in home_html, "home page missing canvas lab link"
+
+
+def test_simulator_links_to_multipage_lab(simulator_html: str) -> None:
+    assert 'href="./lab/index.html"' in simulator_html, "simulator missing multi-page lab link"
+    assert 'href="./agents-demo.html"' in simulator_html, "simulator missing canvas playground link"
 
 
 def test_lab_links_back_to_home(lab_html: str) -> None:
@@ -166,19 +208,22 @@ def test_lab_links_back_to_home(lab_html: str) -> None:
 
 # ─── JS syntax ────────────────────────────────────────────────────────────
 
-@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_js_has_no_syntax_errors(lab_script: str) -> None:
     """Run the embedded script through ``node --check``.
 
     We pass it as ``module`` syntax via a temp ``.mjs`` so top-level returns
     aren't an issue. The script is wrapped in an IIFE so it parses standalone.
     """
+    node = runnable_node()
+    if node is None:
+        pytest.skip("node not runnable on PATH")
+
     with tempfile.NamedTemporaryFile("w", suffix=".mjs", delete=False) as f:
         f.write(lab_script)
         path = f.name
     try:
         proc = subprocess.run(
-            ["node", "--check", path],
+            [node, "--check", path],
             capture_output=True, text=True, check=False, timeout=15,
         )
     finally:

--- a/web/SCENES.md
+++ b/web/SCENES.md
@@ -1,6 +1,6 @@
-# Adding a scene to the agent-payments lab
+# Adding a scene to the agent-payments canvas lab
 
-The lab (`web/agents-demo.html`) is a single static HTML file, no build
+The canvas lab (`web/agents-demo.html`) is a single static HTML file, no build
 step. Each "scene" is a self-contained object you append to the
 `SCENES` registry plus an entry in `SCENE_GROUPS`. Hot-swap any time.
 
@@ -139,7 +139,7 @@ Shape conventions:
 
 ## Tests
 
-`tests/test_web_lab.py` runs over the lab on every PR. If you add a
+`tests/test_web_lab.py` runs over the canvas lab on every PR. If you add a
 scene:
 
 1. Append your id to `EXPECTED_SCENES`.

--- a/web/simulator.html
+++ b/web/simulator.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 <title>switchboard-simulator — compose a scenario</title>
-<meta name="description" content="Compose an agentic-payments scenario: pick a template, currency, and parameters. Outputs a shareable URL that opens the switchboard lab with your scenario applied." />
+<meta name="description" content="Compose an agentic-payments scenario: pick a template, currency, and parameters. Outputs a shareable URL that opens the switchboard canvas playground with your scenario applied." />
 <style>
   :root,
   :root[data-theme="dark"] {
@@ -131,7 +131,9 @@
   <div class="crumbs">
     <a href="./index.html">explorer</a>
     <span>·</span>
-    <a href="./agents-demo.html">lab</a>
+    <a href="./lab/index.html">lab</a>
+    <span>/</span>
+    <a href="./agents-demo.html">canvas</a>
     <span>·</span>
     <a href="https://github.com/kcolbchain/switchboard" target="_blank">source</a>
   </div>
@@ -141,7 +143,7 @@
   <div class="hero">
     <h2>Compose a switchboard scenario.</h2>
     <p>Pick a template, choose a currency, tune the parameters. The simulator outputs a shareable URL that opens the
-       <a href="./agents-demo.html">switchboard lab</a> with your exact scenario applied. Drop the link in a thread,
+       <a href="./agents-demo.html">switchboard canvas playground</a> with your exact scenario applied. Drop the link in a thread,
        and anyone who clicks it sees the same scene with the same numbers.</p>
   </div>
 


### PR DESCRIPTION
Addresses part of #102.

## Summary
- add smoke coverage for all 13 `web/lab/*.html` production lab pages listed in #102
- make the simulator breadcrumb point `lab` at `web/lab/index.html` while keeping the canvas playground link explicit
- clarify `web/SCENES.md` and existing tests so `agents-demo.html` is named as the canvas lab, not the full multi-page lab
- make the node syntax check skip when a `node` shim exists but is not executable in local Windows environments

## Validation
- `PYTHONUTF8=1 C:\Users\13716\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests/test_web_lab.py -q` -> 34 passed, 1 skipped
- `git diff --check`