### PR TITLE
fix(lucidly): status() idle_target_pct must be a 0..1 fraction (was 100x off)

### DIFF
--- a/switchboard/adapters/lucidly.py
+++ b/switchboard/adapters/lucidly.py
@@ -232,5 +232,5 @@ class LucidlyAutoPark:
                 "vault_balance_usd": self.vault.balance(chain),
                 "total_parked_usd": self._total_parked,
                 "enabled": self.config.enabled,
-                "idle_target_pct": self.config.per_chain_targets.get(chain, self.config.idle_target_bps) / 100.0,
+                "idle_target_pct": self._target_bps(chain) / 10_000.0,
             }

--- a/tests/test_lucidly.py
+++ b/tests/test_lucidly.py
@@ -76,6 +76,31 @@ def test_status():
     assert status["idle_target_pct"] > 0
 
 
+def test_status_idle_target_pct_is_a_fraction_matching_config_convention():
+    # `idle_target_pct` must use the same bps->fraction convention everywhere:
+    # LucidlyConfig.idle_target_pct (= bps / 10_000) and the rebalance math
+    # (target_pct = bps / 10_000) both yield a 0..1 fraction. status() used
+    # `/ 100` instead, returning a value 100x too large (e.g. 80.0 vs 0.8).
+    config = LucidlyConfig(per_chain_targets={"base": 8000}, idle_target_bps=8000)
+    park = LucidlyAutoPark(config=config)
+    park.rebalance("base", liquid_balance_usd=10_000.0)
+
+    status = park.status("base")
+    assert status["idle_target_pct"] == 0.8
+    assert status["idle_target_pct"] == config.idle_target_pct
+    # A fraction in [0, 1], not a percentage.
+    assert 0.0 <= status["idle_target_pct"] <= 1.0
+
+
+def test_status_idle_target_pct_falls_back_to_default_bps_as_fraction():
+    # Chain absent from per_chain_targets falls back to idle_target_bps,
+    # still expressed as a 0..1 fraction (not 50.0).
+    config = LucidlyConfig(per_chain_targets={}, idle_target_bps=5000)
+    park = LucidlyAutoPark(config=config)
+    status = park.status("optimism")
+    assert status["idle_target_pct"] == 0.5
+
+
 def test_different_chain_targets():
     config = LucidlyConfig(per_chain_targets={"ethereum": 5000, "base": 8000})
     park = LucidlyAutoPark(config=config)


### PR DESCRIPTION
## Problem

`LucidlyAutoPark.status()` reports `idle_target_pct` using `bps / 100`, so an 8000-bps target is returned as **`80.0`**. Everywhere else in the module the *same quantity* is a `0..1` fraction:

| location | conversion | 8000 bps → |
|---|---|---|
| `LucidlyConfig.idle_target_pct` (same name!) | `idle_target_bps / 10_000` | `0.8` |
| `rebalance()` math | `target_pct = self._target_bps(chain) / 10_000` | `0.8` |
| `ensure_liquid()` | `unpark_threshold_bps / 10_000` | — |
| **`status()`** (this bug) | `... / 100` | **`80.0`** ❌ |

So the public `status()["idle_target_pct"]` disagrees with the **identically named** `LucidlyConfig.idle_target_pct` by 100x.

Reproduction on current `main`:

```python
from switchboard.adapters.lucidly import LucidlyAutoPark, LucidlyConfig
p = LucidlyAutoPark(); p.rebalance("base", 10_000.0)
p.status("base")["idle_target_pct"]   # -> 80.0
LucidlyConfig().idle_target_pct       # -> 0.8   (same name, 100x smaller)
```

A consumer that sizes the idle target from `status()` (e.g. `balance * idle_target_pct`) would overshoot by 100x.

## Fix

Reuse the existing `_target_bps()` helper and the module's `/ 10_000` convention so `status()` returns the same fraction as the config property and the rebalance logic. One-line change; no behavior change to the parking math itself.

## Tests

- `test_status_idle_target_pct_is_a_fraction_matching_config_convention` — pins `status() == config.idle_target_pct == 0.8` and `0 ≤ pct ≤ 1`.
- `test_status_idle_target_pct_falls_back_to_default_bps_as_fraction` — fallback path (chain absent from `per_chain_targets`) also returns a fraction.

`pytest tests/test_lucidly.py` → 15 passed. Full suite → 218 passed, 62 skipped. `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)