### PR TITLE
fix(nonce_manager): skip out-of-order-confirmed nonces on acquire

### DIFF
--- a/switchboard/nonce_manager.py
+++ b/switchboard/nonce_manager.py
@@ -223,16 +223,24 @@ class NonceManager:
         self._ensure_pending_records(state)
 
         # Determine the next available nonce: the lowest nonce at or above
-        # `confirmed_nonce` that is not already pending. Walking up from
-        # `confirmed_nonce` (rather than taking ``max(pending) + 1``) means a
-        # nonce freed by `release_nonce` or a gap left by an out-of-order
-        # confirmation is reused before the sequence is extended. Ethereum
-        # requires gapless nonces, so leaving a hole would stall every
-        # higher-nonce pending tx until the gap is filled.
+        # `confirmed_nonce` that is neither already pending nor already
+        # confirmed out-of-order. Walking up from `confirmed_nonce` (rather
+        # than taking ``max(pending) + 1``) means a nonce freed by
+        # `release_nonce` or a gap left by an out-of-order confirmation is
+        # reused before the sequence is extended. Ethereum requires gapless
+        # nonces, so leaving a hole would stall every higher-nonce pending tx
+        # until the gap is filled.
+        #
+        # `out_of_order_confirmations` must be skipped too: a nonce confirmed
+        # ahead of `confirmed_nonce` is already mined on-chain but is not in
+        # `pending_nonces` (it was dropped on confirmation), so a plain
+        # pending-only walk would re-hand it out and the chain would reject the
+        # new tx with "nonce too low", stalling the queue.
         next_nonce = state.confirmed_nonce
-        for pending in state.pending_nonces.irange(minimum=next_nonce):
-            if pending != next_nonce:
-                break
+        while (
+            next_nonce in state.pending_nonces
+            or next_nonce in state.out_of_order_confirmations
+        ):
             next_nonce += 1
 
         self._assert_rebroadcast_alg(

--- a/tests/test_nonce_manager.py
+++ b/tests/test_nonce_manager.py
@@ -238,6 +238,40 @@ class TestNonceManager(unittest.TestCase):
         self.assertEqual(self.nonce_manager.acquire_nonce(self.wallet_address_1, tx_w1_2), 2)
         self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet([0, 1, 2]))
 
+    def test_acquire_skips_out_of_order_confirmed_nonce(self):
+        """
+        A nonce confirmed ahead of `confirmed_nonce` (out-of-order) is already
+        mined on-chain, but it is no longer in `pending_nonces` (it was dropped
+        on confirmation) and it is not below `confirmed_nonce`. The gap-reuse
+        walk must therefore skip it — otherwise `acquire_nonce` re-hands out an
+        already-confirmed nonce and the chain rejects the new tx with "nonce
+        too low", stalling the queue.
+
+        Regression test: previously the walk only consulted `pending_nonces`,
+        so after an out-of-order confirmation it re-issued the confirmed nonce.
+        """
+        # Acquire nonces 0, 1, 2.
+        self.nonce_manager.acquire_nonce(self.wallet_address_1, MockTransaction(0, "w1_0"))
+        self.nonce_manager.acquire_nonce(self.wallet_address_1, MockTransaction(1, "w1_1"))
+        self.nonce_manager.acquire_nonce(self.wallet_address_1, MockTransaction(2, "w1_2"))
+
+        # Nonce 2 is mined out of order while 0 and 1 are still pending.
+        self.nonce_manager.confirm_nonce(self.wallet_address_1, 2)
+        self.assertEqual(self.nonce_manager.get_confirmed_nonce(self.wallet_address_1), 0)
+        self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet([0, 1]))
+
+        # The next acquire must NOT return 2 (already confirmed); it must jump to 3.
+        acquired = self.nonce_manager.acquire_nonce(self.wallet_address_1, MockTransaction(3, "w1_3"))
+        self.assertEqual(acquired, 3)
+        self.assertEqual(self.nonce_manager.get_pending_nonces(self.wallet_address_1), SortedSet([0, 1, 3]))
+
+        # Confirming the remaining pending nonces rolls confirmed_nonce forward
+        # through the stashed out-of-order confirmation of 2.
+        self.nonce_manager.confirm_nonce(self.wallet_address_1, 0)
+        self.nonce_manager.confirm_nonce(self.wallet_address_1, 1)
+        # 0 -> 1 -> 2 (stashed) -> 3 is still pending, so confirmed stops at 3.
+        self.assertEqual(self.nonce_manager.get_confirmed_nonce(self.wallet_address_1), 3)
+
     def test_sync_with_onchain_nonce_external_confirmation(self):
         """
         Tests synchronization with the on-chain nonce when external transactions


### PR DESCRIPTION
## Problem

`NonceManager` supports out-of-order confirmations: `confirm_nonce(n)` for an `n` greater than `confirmed_nonce` drops `n` from `pending_nonces` and stashes it in `out_of_order_confirmations` to be rolled into `confirmed_nonce` once the gap fills.

But `_reserve_next_nonce` (the gap-reuse walk introduced for the `release_nonce`/gap case in #93) only consulted `pending_nonces`. An out-of-order-confirmed nonce is **not** pending (it was dropped) and **not** below `confirmed_nonce`, so the walk happily re-hands it out — even though it is already mined on-chain. The chain then rejects the new transaction with **"nonce too low"**, and because Ethereum requires gapless nonces, every higher-nonce pending tx stalls behind it.

### Reproduction (current `main`)

```python
nm.acquire_nonce(addr)        # 0
nm.acquire_nonce(addr)        # 1
nm.acquire_nonce(addr)        # 2
nm.confirm_nonce(addr, 2)     # mined out of order; pending = {0, 1}
nm.acquire_nonce(addr)        # -> 2  ❌ already confirmed -> "nonce too low"
```

Expected: `3`.

## Fix

`_reserve_next_nonce` now skips nonces present in `out_of_order_confirmations` in addition to `pending_nonces`. Behaviour in the gapless common case (and the #93 release/gap-reuse case) is unchanged.

```python
next_nonce = state.confirmed_nonce
while (
    next_nonce in state.pending_nonces
    or next_nonce in state.out_of_order_confirmations
):
    next_nonce += 1
```

## Tests

- New regression test `test_acquire_skips_out_of_order_confirmed_nonce` — **fails on `main` (`2 != 3`)**, passes with the fix.
- Full suite: **219 passed, 62 skipped**. `ruff check switchboard/nonce_manager.py` clean.

Follow-up to the same gap-reuse logic as #93.
