### PR TITLE
fix(gas_manager): set_limits must pause when tightened limit is below current spend

### DIFF
--- a/switchboard/gas_manager.py
+++ b/switchboard/gas_manager.py
@@ -258,15 +258,21 @@ class GasManager:
     def _update_pause_state_locked(
         self, ledger: _WalletLedger, limits: GasLimits
     ) -> None:
-        """Re-evaluate pause flag after limit changes."""
-        if not ledger.paused:
-            return
-        still_exhausted = (
+        """Re-evaluate the pause flag after a limit change, in BOTH directions.
+
+        Mirrors ``GasTracker._update_pause_state``: tightening a wallet's limit
+        below its current spend must *pause* it, and loosening the limit above
+        the current spend must *unpause* it. The previous implementation only
+        cleared an existing pause and never set one, so lowering a limit below
+        the recorded spend left ``is_paused()`` reporting ``False`` while
+        ``can_spend()`` (correctly) returned ``False`` — an inconsistency that
+        breaks the documented drop-in parity with ``GasTracker``.
+        """
+        self._evict_locked(ledger, limits)
+        ledger.paused = (
             (limits.per_hour is not None and ledger.sum_hour >= limits.per_hour)
             or (limits.per_day is not None and ledger.sum_day >= limits.per_day)
         )
-        if not still_exhausted:
-            ledger.paused = False
 
     def _status_locked(
         self, wallet: str, ledger: _WalletLedger, limits: GasLimits

--- a/tests/test_gas_manager.py
+++ b/tests/test_gas_manager.py
@@ -428,6 +428,22 @@ class TestGasManager:
         assert m.is_paused(WALLET) is True
         assert m.can_spend(WALLET, 1) is False
 
+    def test_set_limits_above_spend_unpauses_consistently(self):
+        # The other direction of the same symmetry: a wallet paused because its
+        # limit sits below current spend must *unpause* the moment set_limits
+        # raises the limit back above the spend, and is_paused() must again
+        # agree with can_spend(). Guards the "BOTH directions" contract in
+        # _update_pause_state_locked against a future regression that restores
+        # only the pause half.
+        m = GasManager(default_limits=GasLimits(per_hour=100))
+        m.record(WALLET, 150)  # over the limit -> paused
+        assert m.is_paused(WALLET) is True
+        assert m.can_spend(WALLET, 1) is False
+
+        m.set_limits(WALLET, GasLimits(per_hour=200))  # now above the 150 spent
+        assert m.is_paused(WALLET) is False
+        assert m.can_spend(WALLET, 1) is True
+
     def test_evict_respects_hourly_boundary(self):
         clock = FakeClock()
         m = GasManager(default_limits=GasLimits(per_hour=1000), clock=clock)

--- a/tests/test_gas_manager.py
+++ b/tests/test_gas_manager.py
@@ -404,6 +404,30 @@ class TestGasManager:
         m.set_limits(WALLET, GasLimits(per_hour=120))
         assert m.is_paused(WALLET) is True
 
+    def test_set_limits_below_spend_pauses_and_stays_consistent(self):
+        # A wallet healthy under its current limit must become paused when
+        # set_limits tightens the limit below its current spend — and
+        # is_paused() must agree with can_spend(). Regression: the old
+        # _update_pause_state_locked only cleared a pause, never set one, so
+        # is_paused() reported False while can_spend() returned False.
+        m = GasManager(default_limits=GasLimits(per_hour=200))
+        m.record(WALLET, 150)
+        assert m.is_paused(WALLET) is False
+        assert m.can_spend(WALLET, 1) is True
+
+        m.set_limits(WALLET, GasLimits(per_hour=100))  # now below the 150 spent
+        assert m.can_spend(WALLET, 1) is False
+        assert m.is_paused(WALLET) is True  # must not disagree with can_spend
+
+    def test_set_limits_per_day_below_spend_pauses(self):
+        m = GasManager(default_limits=GasLimits(per_day=20_000))
+        m.record(WALLET, 9_000)
+        assert m.is_paused(WALLET) is False
+
+        m.set_limits(WALLET, GasLimits(per_day=5_000))
+        assert m.is_paused(WALLET) is True
+        assert m.can_spend(WALLET, 1) is False
+
     def test_evict_respects_hourly_boundary(self):
         clock = FakeClock()
         m = GasManager(default_limits=GasLimits(per_hour=1000), clock=clock)


### PR DESCRIPTION
## Summary

`GasManager` is documented as a drop-in replacement for both `GasBudgetTracker` and `GasTracker` "without behavioural surprises" (issue #97). It isn't, for one path: tightening a wallet's limit below its current spend via `set_limits()` leaves `is_paused()` and `can_spend()` disagreeing.

`_update_pause_state_locked` early-returned unless the wallet was *already* paused:

```python
def _update_pause_state_locked(self, ledger, limits):
    if not ledger.paused:
        return        # <-- can only CLEAR a pause, never SET one
    ...
```

So lowering a limit below the recorded spend never flips `paused` to `True`. The reference `GasTracker._update_pause_state` recomputes the flag in **both** directions (`_is_paused = not (can_proceed_hourly and can_proceed_daily)`).

## Impact

A consumer migrating from `GasTracker` that gates dispatch on the compatibility alias `is_paused()` after tightening a wallet budget will believe the wallet is healthy and keep sending, while `can_spend()` (correctly) rejects. Budget-enforcement state becomes internally inconsistent.

## Reproduction (before fix)

```python
m = GasManager(default_limits=GasLimits(per_hour=200))
m.record("0xA", 150)                       # healthy
m.set_limits("0xA", GasLimits(per_hour=100))   # tighten below the 150 spent
m.is_paused("0xA")     # -> False   (wrong)
m.can_spend("0xA", 1)  # -> False   (correct)  => disagree
```

The reference `GasTracker` reports `is_paused() == True` after the equivalent operation.

## Fix

Recompute the pause flag in both directions after evicting aged events (`set_limits` previously also skipped eviction, so the sums it read could be stale). Loosening a limit still unpauses; tightening below current spend now pauses.

## Tests

- `test_set_limits_below_spend_pauses_and_stays_consistent` (per-hour)
- `test_set_limits_per_day_below_spend_pauses` (per-day)

Both fail on `main` (`is_paused()` returns `False`), pass with the fix. Existing `test_pause_on_hit_release_on_set_limits` / `test_pause_stays_if_new_limits_still_exceeded` still pass. Full Python suite: 220 passed, 62 skipped (1 pre-existing unrelated `flask` import failure in `test_x402_server`), `gas_manager.py` ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)