### PR TITLE
fix(lucidly): distinct keys for same-chain parks at the same clock value

### DIFF
--- a/switchboard/adapters/lucidly.py
+++ b/switchboard/adapters/lucidly.py
@@ -108,6 +108,9 @@ class LucidlyAutoPark:
         self._wallet_total_usd: dict[str, float] = {}
         self._total_parked: float = 0.0
         self._total_yield: float = 0.0
+        # Monotonic suffix so two parks on the same chain at the same clock
+        # value get distinct keys instead of silently overwriting each other.
+        self._position_seq: int = 0
 
     def _target_bps(self, chain: str) -> int:
         return self.config.per_chain_targets.get(chain, self.config.idle_target_bps)
@@ -157,7 +160,8 @@ class LucidlyAutoPark:
                 syUSD_shares=shares,
                 parked_at=self.clock(),
             )
-            self._positions[f"{chain}:{self.clock()}"] = position
+            self._position_seq += 1
+            self._positions[f"{chain}:{self.clock()}:{self._position_seq}"] = position
             self._liquid_buffer[chain] = current_liquid - excess
             self._total_parked += excess
 

--- a/tests/test_lucidly.py
+++ b/tests/test_lucidly.py
@@ -141,3 +141,24 @@ def test_ensure_liquid_unparks_to_threshold_buffer():
 
     assert returned == 500.0
     assert park.status("base")["liquid_buffer_usd"] == 1_500.0
+
+
+def test_two_parks_same_chain_same_clock_are_distinct_positions():
+    # The position key was `chain:clock()`. The adapter takes an injectable
+    # deterministic clock ("Pluggable clock for deterministic tests"), so two
+    # parks on the same chain at the same clock value mapped to the SAME key —
+    # the second ParkedPosition silently overwrote the first, dropping its
+    # per-position yield accrual even though `_total_parked` still counted both.
+    fixed_t = 1_000_000.0
+    park = LucidlyAutoPark(clock=lambda: fixed_t)
+
+    r1 = park.rebalance("base", liquid_balance_usd=10_000.0)
+    r2 = park.rebalance("base", liquid_balance_usd=10_000.0)
+    assert r1["action"] == "parked"
+    assert r2["action"] == "parked"
+
+    report = park.yield_report()
+    # Both park events must be retained as distinct positions, and the position
+    # count must stay consistent with the parked total (which already sums both).
+    assert report["positions"] == 2
+    assert report["total_parked_usd"] == r1["amount_usd"] + r2["amount_usd"]


### PR DESCRIPTION
### Bug
`LucidlyAutoPark.rebalance()` keys each `ParkedPosition` by `f"{chain}:{self.clock()}"`. The adapter accepts an **injectable clock** (the docstring states *"Pluggable clock for deterministic tests"*), so two parks on the same chain at the same clock value produce the **same dict key** — the second `ParkedPosition` silently overwrites the first.

`_total_parked` (and `vault.balance`) still account for both deposits, so the in-memory positions map diverges from the parked total. Concretely:

- `yield_report()["positions"]` under-counts active positions.
- Per-position `yield_accrued_usd` for the overwritten park is lost (each `ParkedPosition` tracks its own yield).

With a fixed/deterministic clock this is **guaranteed** on the 2nd same-chain park; with real `time.time()` it can still collide on rapid successive parks.

### Fix
Append a monotonic per-instance sequence to the position key so distinct park events never collide. `yield_report()` / `status()` only read `k.split(":")[0]` and `k.startswith(f"{chain}:")`, so the extra `:<seq>` suffix is backward-compatible.

### Test
Added `test_two_parks_same_chain_same_clock_are_distinct_positions` using the injectable clock:
- **Before:** `report["positions"] == 1` (collision) → fails.
- **After:** `report["positions"] == 2` and matches `r1+r2` parked amounts.

Full suite: **223 passed, 62 skipped**. `ruff check` clean on changed files.