### PR TITLE
docs(readme): swap hard-coded tests-passing shield for real Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Programmable payments for AI agents.** One Python library, one contract suite, and one binary wire format that lets agents pay each other for work — over HTTP/402, on-chain escrow, multi-party micropayments, or stablecoin rails — without a human in the loop.
 
-[![tests](https://img.shields.io/badge/tests-passing-brightgreen)](#test-results) [![python](https://img.shields.io/badge/python-3.11+-blue)](https://www.python.org/) [![status](https://img.shields.io/badge/status-active-success)](https://github.com/kcolbchain/switchboard) [![org](https://img.shields.io/badge/org-kcolbchain-7c3aed)](https://kcolbchain.com)
+[![CI](https://github.com/kcolbchain/switchboard/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/switchboard/actions/workflows/ci.yml) [![python](https://img.shields.io/badge/python-3.11+-blue)](https://www.python.org/) [![status](https://img.shields.io/badge/status-active-success)](https://github.com/kcolbchain/switchboard) [![org](https://img.shields.io/badge/org-kcolbchain-7c3aed)](https://kcolbchain.com)
 
 ---
 


### PR DESCRIPTION
## Summary

The README's \`tests-passing\` shield was a static \`img.shields.io/badge/tests-passing-brightgreen\` string — decoupled from the actual \`ci.yml\` workflow status. So the badge always read \"passing\" regardless of whether CI was green.

Replace it with the real \`actions/workflows/ci.yml/badge.svg\` so README state reflects build state.

\`\`\`diff
-[![tests](https://img.shields.io/badge/tests-passing-brightgreen)](#test-results)
+[![CI](https://github.com/kcolbchain/switchboard/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/switchboard/actions/workflows/ci.yml)
\`\`\`

Single-line change. The rest of the badge row (python, status, org) is preserved.