### PR TITLE
eips: finalize native-ETH A2A escrow as a Standards-Track ERC (#50)

### DIFF
--- a/eips/SUBMISSION-CHECKLIST.md
+++ b/eips/SUBMISSION-CHECKLIST.md
@@ -1,0 +1,98 @@
+# ethereum/EIPs submission checklist
+
+How to take `eips/draft-native-eth-a2a-escrow.md` from this repo to a numbered, merged
+Draft EIP in [`ethereum/EIPs`](https://github.com/ethereum/EIPs). Follow [EIP-1] for the
+authoritative process; this is the condensed operational path.
+
+[EIP-1]: https://eips.ethereum.org/EIPS/eip-1
+
+---
+
+## 0. Preconditions (do these first)
+
+- [ ] **GitHub handles in `author:` are real and resolve.** EIP-1 requires every `@handle` to be a
+      valid GitHub account. Confirm `@abhicris`, `@Pattermesh`, `@kcolbchain` all exist. If an author
+      prefers name-only, use `Name <email>` form instead — but at least one author must be reachable.
+- [ ] **Open the ethereum-magicians thread** (see `eips/magicians-post-draft.md`) and let it gather a
+      little discussion. The EIP bot/editors expect a real `discussions-to:` URL.
+- [ ] **Reference implementation is public and stable.** `contracts/AgentEscrow.sol` must be reachable
+      at a permanent URL. EIP body links into this repo are fine, but editors prefer the spec be
+      self-contained — the normative interface lives in the EIP text, not only in the repo.
+- [ ] **Close the two known conformance gaps** (or keep them as clearly-flagged TODOs in the
+      Reference Implementation section, which the current draft does): add ERC-165 `supportsInterface`
+      to the reference contract and a `test_supportsInterface` asserting `0x5c3738e9`.
+
+## 1. Fork and branch
+
+- [ ] Fork [`ethereum/EIPs`](https://github.com/ethereum/EIPs) to your account.
+- [ ] `git clone` your fork; `git checkout -b eip-native-eth-a2a-escrow`.
+- [ ] Read `ethereum/EIPs`'s `CONTRIBUTING` and the EIP template once more — the repo CI
+      (`eipw` linter + HTML preview build) is strict and will reject on format alone.
+
+## 2. File naming and number
+
+- [ ] **Do NOT pick your own number.** New EIPs are submitted as `EIPS/eip-draft_<slug>.md` or you
+      may use a placeholder; an **EIP editor assigns the number** during review. In practice the
+      common path is: name the file `EIPS/eip-XXXX.md` (literal `XXXX`) and set `eip: XXXX`, or use a
+      descriptive `eip-draft_native_eth_a2a_escrow.md`. The editor renames it to the assigned number
+      (`eip-7xxx.md`) on merge.
+- [ ] Copy `eips/draft-native-eth-a2a-escrow.md` into `EIPS/` in the fork under that name.
+- [ ] Place asset files (diagrams, if any are externalized) under `assets/eip-XXXX/`. The current
+      draft uses only inline ASCII, so no assets are needed.
+
+## 3. Frontmatter cleanup (the two placeholders)
+
+- [ ] Set `discussions-to:` to the actual ethereum-magicians topic URL.
+- [ ] Set `eip:` to match the filename. If using the `XXXX` placeholder, leave both as `XXXX`; the
+      editor fills them. **Remove the `EDITOR NOTE` HTML comment block** at the top of the draft.
+- [ ] Confirm the rest of the frontmatter is exactly the EIP-1 set in the right order:
+      `eip, title, description, author, discussions-to, status, type, category, created, requires`.
+      - `status: Draft`
+      - `type: Standards Track`
+      - `category: ERC`
+      - `requires: 165`
+      - `title` ≤ 44 chars, `description` ≤ 140 chars, neither ending in a period, neither
+        repeating the word "standard"/"EIP" (eipw enforces these).
+
+## 4. Body conformance (what the linter and editors check)
+
+- [ ] Required sections present and in EIP-1 order: **Abstract, Motivation, Specification, Rationale,
+      Backwards Compatibility, Reference Implementation, Security Considerations, Copyright**
+      (plus optional Test Cases — present here). All eight required headers are `##` level.
+- [ ] **RFC-2119 keywords** boilerplate paragraph present in Specification (it is).
+- [ ] **Copyright** is exactly the CC0 waiver line EIP-1 mandates (it is).
+- [ ] Internal links to other EIPs use the relative `./eip-N.md` form (the draft links ERC-165 as
+      `./eip-165.md` — correct).
+- [ ] No broken external links; `eipw` checks reachability of some.
+- [ ] Markdown passes the repo's `markdownlint` config (line length is not capped, but tables and
+      headers must be well-formed).
+
+## 5. Open the PR
+
+- [ ] Push the branch to your fork; open a PR into `ethereum/EIPs:master`.
+- [ ] PR title convention: `Add EIP: Native-ETH Agent-to-Agent Escrow` (or
+      `Add ERC: ...`). The bot comments with the assigned number and lint results within minutes.
+- [ ] Address every `eipw` / preview-CI failure. Re-push; CI re-runs.
+- [ ] An **EIP editor** reviews for format + EIP-1 conformance (NOT for whether the idea is good —
+      that's the magicians thread's job). Once it conforms, an editor assigns the number, may rename
+      the file, and merges it as **Draft**.
+
+## 6. After merge
+
+- [ ] Update the `discussions-to` thread title and this repo's `eips/draft-native-eth-a2a-escrow.md`
+      frontmatter to reference the assigned `ERC-XXXX` number, and link the merged EIP from issue #50
+      and PR #51.
+- [ ] Advancing **Draft → Review → Last Call → Final** is a later, separate process driven by author
+      readiness + editor sign-off + the discussion thread; it is out of scope for initial submission.
+
+---
+
+### Quick reference: what an editor will and won't gate on
+
+| Editor gates on (must fix to merge) | Editor does NOT gate on |
+|---|---|
+| Frontmatter format, field order, char limits | Whether the primitive is a good idea |
+| All required sections present, correct order | Whether the community agrees with the design |
+| Valid author handles, real `discussions-to` | Adoption / deployment count |
+| CC0 copyright line verbatim | Test coverage depth |
+| Relative EIP links, lint pass | The bikeshed in §Rationale |

--- a/eips/draft-native-eth-a2a-escrow.md
+++ b/eips/draft-native-eth-a2a-escrow.md
@@ -1,15 +1,27 @@
 ---
-eip: <TBD — request from EIP editors>
+eip: <to be assigned by an EIP editor on PR>
 title: Native-ETH Agent-to-Agent Escrow
 description: A minimal payable escrow primitive for autonomous agent-to-agent payments using native ETH, with timeout-based refund and explicit challenge period.
 author: Abhishek Krishna (@abhicris), Pattermesh (@Pattermesh), kcolbchain (@kcolbchain)
-discussions-to: https://ethereum-magicians.org/<TBD>
+discussions-to: <ethereum-magicians.org thread URL — to be filled before opening the ethereum/EIPs PR>
 status: Draft
 type: Standards Track
 category: ERC
 created: 2026-05-24
 requires: 165
 ---
+
+<!--
+  EDITOR NOTE (remove before submitting to ethereum/EIPs):
+  Two frontmatter fields are intentionally placeholders because the EIP process
+  forbids self-assigning them:
+    - `eip:` is assigned by an EIP editor when the submission PR is opened
+      (file is named `eip-XXXX.md`); ethereum/EIPs CI normally fills it.
+    - `discussions-to:` MUST be a live ethereum-magicians.org thread. Open the
+      thread first (see eips/magicians-post-draft.md), then paste the URL here.
+  Everything else in this document is final and editor-ready.
+-->
+
 
 ## Abstract
 
@@ -98,7 +110,10 @@ interface IAgentEscrow {
     ///         by the original payer. Returns the funds to the payer.
     function cancelPayment(string calldata requestId) external;
 
-    /// @notice Read the payment record.
+    /// @notice Read the payment record. The return shape is illustrative;
+    ///         the ERC-165 selector depends only on the argument types
+    ///         (`string`), so a `returns (Payment)` struct form is
+    ///         equally conformant.
     function getPayment(string calldata requestId) external view returns (
         address payer,
         address payee,
@@ -114,9 +129,13 @@ interface IAgentEscrow {
 }
 ```
 
-The ERC-165 interface identifier is **`0x5c3738e9`**, computed as the XOR of the six selectors in `IAgentEscrow`:
+### ERC-165 interface identifier
 
-| Function | Selector |
+The interface identifier of `IAgentEscrow` is **`0x5c3738e9`**.
+
+It is the XOR of the [Solidity ABI](https://docs.soliditylang.org/en/latest/abi-spec.html#function-selector) function selectors of the six member functions, per [ERC-165](./eip-165.md). A function selector is the first four bytes of `keccak256` of the canonical signature — the function name and the parenthesized argument types only. Return types, the `payable`/`view`/`external` modifiers, and `address` vs `address payable` do **not** affect the selector. The six signatures and selectors are:
+
+| Function (canonical signature) | Selector |
 |---|---|
 | `createPayment(string,address,uint256,uint256)` | `0x8a5d6ff0` |
 | `confirmPayment(string)` | `0x912db0fb` |
@@ -125,7 +144,30 @@ The ERC-165 interface identifier is **`0x5c3738e9`**, computed as the XOR of the
 | `getPayment(string)` | `0xc69207a3` |
 | `isExpired(string)` | `0xc64fafbc` |
 
-A compliant contract MUST return `true` from `supportsInterface(0x5c3738e9)`.
+Running XOR (left to right):
+
+```
+  0x8a5d6ff0
+^ 0x912db0fb  = 0x1b70df0b
+^ 0xc38821fc  = 0xd8f8fef7
+^ 0x84126e01  = 0x5cea90f6
+^ 0xc69207a3  = 0x9a789755
+^ 0xc64fafbc  = 0x5c3738e9   ← interface id
+```
+
+The computation is reproducible with Foundry:
+
+```bash
+cast sig "createPayment(string,address,uint256,uint256)"  # 0x8a5d6ff0
+cast sig "confirmPayment(string)"                         # 0x912db0fb
+cast sig "requestRefund(string)"                          # 0xc38821fc
+cast sig "cancelPayment(string)"                          # 0x84126e01
+cast sig "getPayment(string)"                             # 0xc69207a3
+cast sig "isExpired(string)"                              # 0xc64fafbc
+# XOR of all six = 0x5c3738e9
+```
+
+A compliant contract MUST implement [ERC-165](./eip-165.md) and MUST return `true` from `supportsInterface(0x5c3738e9)` and from `supportsInterface(0x01ffc9a7)` (the ERC-165 identifier itself).
 
 ### Required events
 
@@ -144,6 +186,35 @@ event PaymentCancelled(string indexed requestId, address indexed payer, uint256 
 A compliant contract MUST emit `PaymentCreated` from `createPayment`, and exactly one of `PaymentReleased`, `PaymentRefunded`, or `PaymentCancelled` per request id when reaching the terminal state.
 
 The `requestId` field is `indexed` even though it is a `string`; per the ABI specification, the topic is `keccak256(requestId)`. Off-chain indexers SHOULD hash off-chain request ids to query the log.
+
+### Errors
+
+A compliant contract MUST revert (it MUST NOT silently no-op or return `false`) when a precondition is violated. The normative revert conditions are:
+
+| Function | MUST revert when |
+|---|---|
+| `createPayment` | `bytes(requestId).length == 0`; `payee == address(0)`; `timeoutBlocks == 0`; `msg.value == 0`; or `requestId` is already in use in this contract instance |
+| `confirmPayment` | caller is not the payer; `state != Locked`; or `block.number >= createdAt + timeoutBlocks` (window closed) |
+| `requestRefund` | caller is not the payer; `state != Locked`; or `block.number < createdAt + timeoutBlocks + challengePeriod` (challenge window not elapsed) |
+| `cancelPayment` | caller is not the payer; or `state != Locked` |
+| any terminal transition | the ETH transfer to the recipient fails (the state change MUST be rolled back with the revert) |
+
+The reason strings or [custom errors](https://docs.soliditylang.org/en/latest/contracts.html#errors-and-the-revert-statement) used are NOT normative — only the *fact* of reverting is. Implementations are RECOMMENDED to use named custom errors for cheaper reverts and machine-readable cause codes, for example:
+
+```solidity
+error RequestIdInUse(string requestId);
+error EmptyRequestId();
+error ZeroPayee();
+error ZeroTimeout();
+error ZeroValue();
+error NotPayer(address caller);
+error NotLocked(string requestId);
+error WindowClosed(string requestId);      // confirm after timeout
+error ChallengeNotElapsed(string requestId); // refund before challenge end
+error TransferFailed(address recipient, uint256 amount);
+```
+
+The reference implementation currently uses `require` reason strings; the migration to custom errors is editorial and does not change the interface id.
 
 ### Checks, effects, interactions
 
@@ -199,33 +270,37 @@ Implementations MUST NOT silently accept ERC-20 token transfers (`ERC-20::transf
 
 ## Reference Implementation
 
-The reference implementation is [`contracts/AgentEscrow.sol`](../contracts/AgentEscrow.sol) in the `kcolbchain/switchboard` repository. The contract is ~180 lines of Solidity ^0.8.20, MIT-licensed, dependency-free. It has been running on Base Sepolia and Lux testnet since April 2026.
+The reference implementation is [`contracts/AgentEscrow.sol`](../contracts/AgentEscrow.sol) in the `kcolbchain/switchboard` repository. It is Solidity ^0.8.20, MIT-licensed, and has been running on Base Sepolia and Lux testnet since April 2026.
 
-Foundry test coverage is in [`tests/`](../tests/) and covers:
+The reference contract is a *superset* of `IAgentEscrow`: it implements the full required interface (with `createPayment`/`confirmPayment`/`requestRefund`/`cancelPayment` returning `bool` and `getPayment` returning a `Payment` struct — neither return-shape difference changes the selectors, hence the interface id is unchanged), plus three non-normative extensions that are out of scope for this base standard:
 
-- `createPayment` success path, value lock, event emission
-- All `createPayment` revert cases (duplicate request id, zero payee, zero timeout, zero value, empty id)
-- `confirmPayment` happy path, only-payer enforcement, expired-window revert
-- `requestRefund` happy path, only-payer, pre-challenge-period revert
-- `cancelPayment` happy path, only-payer, only-locked revert
-- Smart-contract payee receiving via `.call{value:}` + `receive()`
-- Reentrancy via checks-effects-interactions ordering
+- An owner-curated agent allowlist (`registerAgent` / `deregisterAgent`), and
+- An optional oracle-release path (`createPaymentWithPolicy`, `releaseByAttestation`) that consults an external [`IOracleAggregator`](../contracts/IOracleAggregator.sol). This is the concrete shape of the layered extension described in the Rationale; it composes onto the base state machine without altering it.
+
+Two known gaps between the reference contract and this specification, to be closed before the contract is declared conformant (they do not affect the interface id):
+
+1. The reference contract does not yet inherit ERC-165 / expose `supportsInterface`. A conformant deployment MUST add it and return `true` for `0x5c3738e9` and `0x01ffc9a7`.
+2. The reference enum is `{Created, Locked, Confirmed, Released, Refunded, Cancelled}`; the canonical `IAgentEscrow` enum is `{None, Locked, Released, Refunded, Cancelled}`. The on-chain observable state machine is identical (only `Locked` and the three terminals are reachable post-`createPayment`); the extra enum members are implementation detail.
+
+Foundry tests live in [`test/AgentEscrow.t.sol`](../test/AgentEscrow.t.sol) (base primitive) and [`contracts/test/AgentEscrowOracle.t.sol`](../contracts/test/AgentEscrowOracle.t.sol) (allowlist + oracle extension), with a mock aggregator at [`contracts/mocks/MockOracleAggregator.sol`](../contracts/mocks/MockOracleAggregator.sol).
 
 ## Test Cases
 
-The reference implementation's test suite is the canonical test set. Selected cases:
+The reference implementation's Foundry suite is the canonical test set. Selected cases (names as they appear in the suite):
 
 | Test | What it asserts |
 |---|---|
-| `test_createPayment_locksValue` | `address(escrow).balance` increases by `msg.value`; `getPayment(id).state == Locked` |
-| `test_createPayment_revertsOnDuplicateId` | A second `createPayment` with the same `requestId` reverts |
-| `test_confirmPayment_onlyPayer` | `confirmPayment` called by non-payer reverts |
-| `test_confirmPayment_revertsAfterTimeout` | `confirmPayment` at `block.number == createdAt + timeoutBlocks` reverts |
-| `test_requestRefund_revertsBeforeChallenge` | `requestRefund` at `block.number == createdAt + timeoutBlocks + challengePeriod - 1` reverts |
-| `test_requestRefund_succeedsAfterChallenge` | At exactly `createdAt + timeoutBlocks + challengePeriod`, `requestRefund` returns funds |
-| `test_cancelPayment_onlyLocked` | `cancelPayment` on a terminal state reverts |
-| `test_smartContractPayee_receivesValue` | A payee with a `receive()` function receives ETH and emits its own event |
-| `test_supportsInterface` | `supportsInterface(0x5c3738e9) == true`; `supportsInterface(0x12345678) == false` |
+| `test_happyPath_createConfirmReleased` | After `createPayment`, state is `Locked`; after payer `confirmPayment`, state is `Released` and the payee balance increases by `amount` |
+| `test_timeoutRefund_path` | `requestRefund` reverts before `createdAt + timeoutBlocks + challengePeriod`; `isExpired` is true once `block.number >= createdAt + timeoutBlocks`; refund succeeds after the challenge window and state becomes `Refunded` |
+| `test_doubleConfirm_reverts` | A second `confirmPayment` on an already-`Released` request reverts |
+| `test_cancel_returnsFunds` | `cancelPayment` while `Locked` returns funds to the payer and sets state `Cancelled` |
+| `test_onlyPayerCanConfirm` | `confirmPayment` from a non-payer reverts |
+| `test_reentrancy_confirmPayment_reverts` | A malicious payee re-entering `confirmPayment` cannot trigger a second release (state already terminal + guard) |
+| `test_registerAgent_onlyOwner_strangerReverts` | The allowlist extension's `registerAgent` is owner-gated |
+| `test_releaseByAttestation_success` | Oracle-extension release succeeds when the aggregator verifies the attestation; permissionless submitter |
+| `test_releaseByAttestation_revertsAfterTimeout` | Oracle release reverts once the timeout window has closed (use refund instead) |
+
+A `supportsInterface(0x5c3738e9) == true` test MUST be added alongside the ERC-165 implementation noted above; it does not yet exist in the reference suite.
 
 ## Security Considerations
 

--- a/eips/magicians-post-draft.md
+++ b/eips/magicians-post-draft.md
@@ -1,0 +1,72 @@
+# ethereum-magicians forum post — draft
+
+Post this to https://ethereum-magicians.org/ under **Magicians → EIPs** (category: ERC).
+Once the topic is created, copy its URL into the `discussions-to:` frontmatter field of
+`eips/draft-native-eth-a2a-escrow.md` before opening the ethereum/EIPs PR.
+
+---
+
+**Title:** `ERC: Native-ETH Agent-to-Agent Escrow (payable escrow primitive, no token, no arbitrator)`
+
+**Tags:** `erc`, `escrow`, `payments`, `agents`, `eip-165`
+
+---
+
+## Body
+
+Sharing an early Standards-Track ERC draft for feedback before I open the PR to `ethereum/EIPs`.
+
+**The primitive.** A `payable` escrow keyed by a free-form `string requestId`. The payer calls
+`createPayment{value}(requestId, payee, timeoutBlocks, challengePeriod)`; funds sit in `Locked`
+until exactly one of three payer-driven terminals fires:
+
+- `confirmPayment` — release to payee (only before the timeout window closes),
+- `cancelPayment` — return to payer while still locked,
+- `requestRefund` — return to payer, but only after `timeoutBlocks + challengePeriod` has elapsed.
+
+All three terminals are absorbing. That is the whole surface. ERC-165 interface id **`0x5c3738e9`**
+(XOR of the six function selectors — math is in the draft).
+
+**Why it's worth a standard.** Every on-chain agent-payment primitive shipping today (x402's
+SettlementContract, Google A2A payment-claims, Circle Nanopayments, Tempo/MPP) is (1) bound to a
+specific ERC-20, usually USDC, so the payer needs an extra `approve` tx and must trust that token's
+bridge on the target chain; (2) coupled to an off-chain settlement counterparty that can be
+sanctioned or rate-limited; and (3) deployed per-chain by its operator with no portable bytecode.
+
+Native ETH is the only asset present on every EVM chain with no token contract. A `payable` escrow
+removes the `approve` step (saving ~21k–46k gas/payment), removes the off-chain operator, and is the
+same source on mainnet, every L2, and any future EVM chain. We've been running the reference
+implementation on Base Sepolia and Lux testnet since April.
+
+**Deliberate non-goals (defended in the draft's Rationale):**
+
+- **No oracle/arbitration release in the base standard.** Payer-only release is the minimum.
+  Oracle-attested release is a strict *extension* — `releaseByAttestation(string,bytes32,bytes[])`
+  gated by a separate `IOracleAggregator` — layered on, not baked in. Keeps the base auditable.
+- **`string` requestId, not `bytes32`.** Real off-chain ids (UUIDs, HTTP `X-Request-Id`, JWT claims)
+  aren't naturally `bytes32`; hashing them breaks on-chain↔off-chain correlation. The string cost is
+  paid once, on create.
+- **Explicit challenge period after the timeout**, so payer and payee don't race in the same block.
+
+**Draft:** <link to `eips/draft-native-eth-a2a-escrow.md` on the stable `main` URL>
+**Reference implementation:** `contracts/AgentEscrow.sol` (MIT) — <repo link>
+**Animated walkthrough** of happy / refund / cancel paths: <lab link>
+
+## Open questions for the forum
+
+1. **Is the surface the right *minimum*?** payable create, `string` requestId key, timeout +
+   challenge period, three payer-driven terminals. Missing anything load-bearing, or over-including?
+2. **Oracle release — fold in or keep separate?** The draft argues for a separate composable EIP.
+   Is that the right cut, or should attestation-release be in the base interface?
+3. **`string` vs `bytes32` key.** Worth the per-create gas and the indexed-string topic-hash quirk,
+   or should the base standard be `bytes32` with a `string` variant layered on?
+4. **Challenge-period semantics.** The window currently hard-favors the payer (after timeout, only
+   `requestRefund` is callable — payee can no longer confirm). Is "no confirmation in time ⇒ funds
+   return to payer" the right default, or should there be a symmetric payee-claim path?
+5. **`block.number` vs `block.timestamp`** for the windows. We chose block height for reorg-stability
+   reasoning; on chains with variable block times this pushes configuration onto the deployer. Is
+   timestamp the more portable choice?
+6. **ERC-165 only, or also an on-chain registry?** Discovery of conformant deployments per chain is
+   currently out of scope. Does the standard need a canonical registry, or is that a separate concern?
+
+Happy to be told the shape is wrong for an ERC — would rather hear it here than after submission.


### PR DESCRIPTION
Finalizes the AgentEscrow EIP to Standards-Track ERC quality (addresses #50).

- ERC-165 interface id `0x5c3738e9` verified by selector-XOR.
- Adds ethereum-magicians post draft + ethereum/EIPs submission checklist.
- Flags one gap to close pre-submission: reference AgentEscrow.sol lacks supportsInterface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)